### PR TITLE
Use Next.js Image for YouTube thumbnail

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,21 @@ module.exports = {
     ];
   },
 
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'img.youtube.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'i.ytimg.com',
+        pathname: '/**',
+      },
+    ],
+  },
+
   async rewrites() {
     return [
       {

--- a/src/components/LiteYouTube.tsx
+++ b/src/components/LiteYouTube.tsx
@@ -2,6 +2,7 @@
 
 import { useState, memo } from 'react';
 import type { FC } from 'react';
+import Image from 'next/image';
 
 type LiteYouTubeProps = {
   videoId: string;
@@ -22,10 +23,12 @@ const LiteYouTubeComponent: FC<LiteYouTubeProps> = ({ videoId }) => {
           className="w-full h-full flex items-center justify-center"
           aria-label="Assistir vídeo"
         >
-          <img
+          <Image
             src={thumbnail}
             alt="Prévia do vídeo"
-            className="absolute inset-0 w-full h-full object-cover"
+            fill
+            className="absolute inset-0 object-cover"
+            sizes="(max-width: 768px) 100vw, 640px"
           />
           <div className="z-10">
             <svg


### PR DESCRIPTION
## Summary
- replace plain `<img>` with Next.js `<Image>` component in YouTube player
- configure `next.config.js` to allow YouTube thumbnail domains

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68927c9832cc832d9fb9f32854291bcc