### PR TITLE
Fix sitemap domain

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -4,7 +4,7 @@ export async function GET() {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-      <loc>https://solarinves.info/</loc>
+      <loc>https://solarinvest.info/</loc>
       <lastmod>${new Date().toISOString()}</lastmod>
     </url>
     <loc>https://solarinvest.com/</loc>


### PR DESCRIPTION
## Summary
- correct site URL to https://solarinvest.info in generated sitemap

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d54288f28832dbd60664e02e741d1