### PR TITLE
feat: toggle menu aria label

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,8 @@ export default function Header() {
     { name: 'Contato', href: '/contato' },
   ];
 
+  const ariaLabel = menuOpen ? 'Fechar menu' : 'Abrir menu';
+
   return (
     <header className="fixed top-0 z-50 w-full bg-gradient-to-b from-white/70 to-orange-50/30 backdrop-blur-xl shadow-md border-b border-orange-100">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
@@ -72,7 +74,7 @@ export default function Header() {
         <button
           onClick={() => setMenuOpen(!menuOpen)}
           className="md:hidden text-orange-500 focus:outline-none"
-          aria-label="Abrir menu"
+          aria-label={ariaLabel}
         >
           {menuOpen ? <X size={28} /> : <Menu size={28} />}
         </button>


### PR DESCRIPTION
## Summary
- dynamically label mobile menu button based on open state for accessibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689d543ac5b4832da89cc014d449bb6e