### PR TITLE
Fix sitemap XML structure

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -4,12 +4,15 @@ export async function GET() {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-      <loc>https://solarinves.info/</loc>
+      <loc>https://solarinvest.info/</loc>
       <lastmod>${new Date().toISOString()}</lastmod>
     </url>
-    <loc>https://solarinvest.com/</loc>
-    <loc>https://www.instagram.com/solarinvest.br/</loc>
-    
+    <url>
+      <loc>https://solarinvest.com/</loc>
+    </url>
+    <url>
+      <loc>https://www.instagram.com/solarinvest.br/</loc>
+    </url>
   </urlset>`;
 
   return new Response(sitemap, {


### PR DESCRIPTION
## Summary
- correct `https://solarinvest.info/` domain and wrap each `<loc>` inside `<url>` for the sitemap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `python3 - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('/tmp/sitemap.xml')\nprint('sitemap valid')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_689d581836ac832d845afb8c20030ada