### PR TITLE
feat: add metadata for informational pages

### DIFF
--- a/src/app/comofunciona/page.tsx
+++ b/src/app/comofunciona/page.tsx
@@ -1,9 +1,31 @@
-// src/app/comofunciona/page.tsx
-
-'use client';
-
+import type { Metadata } from 'next';
 import React from 'react';
 import ComoFunciona from '@/components/ComoFunciona';
+
+export const metadata: Metadata = {
+  title: 'Como Funciona a Energia Solar | SolarInvest',
+  description:
+    'Veja o passo a passo para implementar energia solar com a SolarInvest, da análise inicial à economia garantida.',
+  keywords: [
+    'SolarInvest',
+    'como funciona',
+    'instalação solar',
+    'processo de energia solar',
+    'economia de energia',
+  ],
+  openGraph: {
+    title: 'Como Funciona a Energia Solar | SolarInvest',
+    description:
+      'Veja o passo a passo para implementar energia solar com a SolarInvest, da análise inicial à economia garantida.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Como Funciona a Energia Solar | SolarInvest',
+    description:
+      'Veja o passo a passo para implementar energia solar com a SolarInvest, da análise inicial à economia garantida.',
+  },
+};
 
 export default function ComoFuncionaPage() {
   return (

--- a/src/app/contato/ContatoContent.tsx
+++ b/src/app/contato/ContatoContent.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import ContatoForm from '@/components/ContatoForm';
+
+export default function ContatoContent() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-3xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Fale com a gente
+        </motion.h1>
+
+        {/* 💬 Subtítulo animado */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-2xl mx-auto mb-10"
+        >
+          Está pronto para transformar sua energia em economia? Preencha o formulário abaixo e entraremos em contato rapidamente.
+        </motion.p>
+
+        {/* 📩 Formulário animado */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          <ContatoForm />
+        </motion.div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -1,41 +1,31 @@
-'use client';
+import type { Metadata } from 'next';
+import ContatoContent from './ContatoContent';
 
-import { motion } from 'framer-motion';
-import ContatoForm from '@/components/ContatoForm';
+export const metadata: Metadata = {
+  title: 'Contato | SolarInvest',
+  description:
+    'Entre em contato com a SolarInvest para solicitar orçamento ou tirar dúvidas sobre nossos sistemas de energia solar.',
+  keywords: [
+    'SolarInvest',
+    'contato',
+    'orçamento',
+    'energia solar',
+    'atendimento',
+  ],
+  openGraph: {
+    title: 'Contato | SolarInvest',
+    description:
+      'Entre em contato com a SolarInvest para solicitar orçamento ou tirar dúvidas sobre nossos sistemas de energia solar.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contato | SolarInvest',
+    description:
+      'Entre em contato com a SolarInvest para solicitar orçamento ou tirar dúvidas sobre nossos sistemas de energia solar.',
+  },
+};
 
 export default function ContatoPage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-3xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Fale com a gente
-        </motion.h1>
-
-        {/* 💬 Subtítulo animado */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-2xl mx-auto mb-10"
-        >
-          Está pronto para transformar sua energia em economia? Preencha o formulário abaixo e entraremos em contato rapidamente.
-        </motion.p>
-
-        {/* 📩 Formulário animado */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-        >
-          <ContatoForm />
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <ContatoContent />;
 }

--- a/src/app/sobre/SobreContent.tsx
+++ b/src/app/sobre/SobreContent.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export default function SobreContent() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-5xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Sobre a SolarInvest
+        </motion.h1>
+
+        {/* 💬 Texto de introdução */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-3xl mx-auto mb-8"
+        >
+          A SolarInvest nasceu com o propósito de democratizar o acesso à energia solar no Brasil.
+          Nosso compromisso é oferecer soluções inteligentes, acessíveis e sustentáveis, permitindo que famílias e empresas economizem e contribuam para um futuro mais limpo.
+        </motion.p>
+
+        {/* ✅ Bloco institucional animado */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="bg-orange-50 rounded-xl shadow-md p-6 text-left mx-auto"
+        >
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Missão</h2>
+          <p className="text-gray-700 mb-4">
+            Tornar a energia solar uma realidade para todos, promovendo economia, autonomia energética e redução do impacto ambiental.
+          </p>
+
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Visão</h2>
+          <p className="text-gray-700 mb-4">
+            Ser referência em soluções fotovoltaicas no Brasil, com foco em inovação, transparência e excelência no atendimento.
+          </p>
+
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossos Valores</h2>
+          <ul className="list-disc list-inside text-gray-700 space-y-1">
+            <li>Transparência e ética em cada etapa</li>
+            <li>Compromisso com resultados reais</li>
+            <li>Respeito ao meio ambiente e às pessoas</li>
+            <li>Inovação constante e melhoria contínua</li>
+          </ul>
+        </motion.div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,58 +1,32 @@
-'use client';
+import type { Metadata } from 'next';
+import SobreContent from './SobreContent';
 
-import { motion } from 'framer-motion';
+export const metadata: Metadata = {
+  title: 'Sobre a SolarInvest | Energia Solar Sustentável',
+  description:
+    'Conheça a missão, visão e valores da SolarInvest e como trabalhamos para democratizar o acesso à energia solar no Brasil.',
+  keywords: [
+    'SolarInvest',
+    'sobre',
+    'missão',
+    'visão',
+    'valores',
+    'energia solar',
+  ],
+  openGraph: {
+    title: 'Sobre a SolarInvest | Energia Solar Sustentável',
+    description:
+      'Conheça a missão, visão e valores da SolarInvest e como trabalhamos para democratizar o acesso à energia solar no Brasil.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Sobre a SolarInvest | Energia Solar Sustentável',
+    description:
+      'Conheça a missão, visão e valores da SolarInvest e como trabalhamos para democratizar o acesso à energia solar no Brasil.',
+  },
+};
 
 export default function SobrePage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-5xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Sobre a SolarInvest
-        </motion.h1>
-
-        {/* 💬 Texto de introdução */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-3xl mx-auto mb-8"
-        >
-          A SolarInvest nasceu com o propósito de democratizar o acesso à energia solar no Brasil.
-          Nosso compromisso é oferecer soluções inteligentes, acessíveis e sustentáveis, permitindo que famílias e empresas economizem e contribuam para um futuro mais limpo.
-        </motion.p>
-
-        {/* ✅ Bloco institucional animado */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-          className="bg-orange-50 rounded-xl shadow-md p-6 text-left mx-auto"
-        >
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Missão</h2>
-          <p className="text-gray-700 mb-4">
-            Tornar a energia solar uma realidade para todos, promovendo economia, autonomia energética e redução do impacto ambiental.
-          </p>
-
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Visão</h2>
-          <p className="text-gray-700 mb-4">
-            Ser referência em soluções fotovoltaicas no Brasil, com foco em inovação, transparência e excelência no atendimento.
-          </p>
-
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossos Valores</h2>
-          <ul className="list-disc list-inside text-gray-700 space-y-1">
-            <li>Transparência e ética em cada etapa</li>
-            <li>Compromisso com resultados reais</li>
-            <li>Respeito ao meio ambiente e às pessoas</li>
-            <li>Inovação constante e melhoria contínua</li>
-          </ul>
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <SobreContent />;
 }

--- a/src/app/solucoes/SolucoesContent.tsx
+++ b/src/app/solucoes/SolucoesContent.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export default function SolucoesContent() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-6xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Nossas Soluções
+        </motion.h1>
+
+        {/* 💬 Subtítulo animado */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-2xl mx-auto mb-12"
+        >
+          Atendemos diferentes perfis de clientes com soluções solares personalizadas, eficientes e acessíveis para transformar sua relação com a energia.
+        </motion.p>
+
+        {/* 🧱 Cards animados */}
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-3 gap-12"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          {/* 🏠 Residencial */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Residencial</h2>
+            <p className="text-gray-700">
+              Energia solar para casas, apartamentos e condomínios. Reduza sua conta e invista em sustentabilidade com segurança e autonomia.
+            </p>
+          </div>
+
+          {/* 🏢 Comercial */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Comercial</h2>
+            <p className="text-gray-700">
+              Projetos para empresas e comércios que buscam economia, previsibilidade e valorização da marca com energia limpa.
+            </p>
+          </div>
+
+          {/* 🌱 Rural e Off-Grid */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Rural e Off-Grid</h2>
+            <p className="text-gray-700">
+              Soluções completas para áreas remotas com energia contínua, mesmo sem acesso à rede elétrica tradicional.
+            </p>
+          </div>
+        </motion.div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/solucoes/page.tsx
+++ b/src/app/solucoes/page.tsx
@@ -1,63 +1,32 @@
-'use client';
+import type { Metadata } from 'next';
+import SolucoesContent from './SolucoesContent';
 
-import { motion } from 'framer-motion';
+export const metadata: Metadata = {
+  title: 'Soluções em Energia Solar | SolarInvest',
+  description:
+    'Conheça soluções solares residenciais, comerciais e off-grid da SolarInvest para reduzir custos e promover sustentabilidade.',
+  keywords: [
+    'SolarInvest',
+    'soluções solares',
+    'residencial',
+    'comercial',
+    'off-grid',
+    'energia renovável',
+  ],
+  openGraph: {
+    title: 'Soluções em Energia Solar | SolarInvest',
+    description:
+      'Conheça soluções solares residenciais, comerciais e off-grid da SolarInvest para reduzir custos e promover sustentabilidade.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Soluções em Energia Solar | SolarInvest',
+    description:
+      'Conheça soluções solares residenciais, comerciais e off-grid da SolarInvest para reduzir custos e promover sustentabilidade.',
+  },
+};
 
 export default function SolucoesPage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-6xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Nossas Soluções
-        </motion.h1>
-
-        {/* 💬 Subtítulo animado */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-2xl mx-auto mb-12"
-        >
-          Atendemos diferentes perfis de clientes com soluções solares personalizadas, eficientes e acessíveis para transformar sua relação com a energia.
-        </motion.p>
-
-        {/* 🧱 Cards animados */}
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-3 gap-12"
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-        >
-          {/* 🏠 Residencial */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Residencial</h2>
-            <p className="text-gray-700">
-              Energia solar para casas, apartamentos e condomínios. Reduza sua conta e invista em sustentabilidade com segurança e autonomia.
-            </p>
-          </div>
-
-          {/* 🏢 Comercial */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Comercial</h2>
-            <p className="text-gray-700">
-              Projetos para empresas e comércios que buscam economia, previsibilidade e valorização da marca com energia limpa.
-            </p>
-          </div>
-
-          {/* 🌱 Rural e Off-Grid */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Rural e Off-Grid</h2>
-            <p className="text-gray-700">
-              Soluções completas para áreas remotas com energia contínua, mesmo sem acesso à rede elétrica tradicional.
-            </p>
-          </div>
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <SolucoesContent />;
 }


### PR DESCRIPTION
## Summary
- add unique metadata, OpenGraph and Twitter tags for about, how-it-works, solutions and contact pages
- move client-only page content into separate components to allow metadata export

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `RESEND_API_KEY=dummy npm run build`
- `curl -s http://localhost:3000/sobre | grep -oP '<title>.*?</title>'`
- `curl -s http://localhost:3000/comofunciona | grep -oP '<title>.*?</title>'`
- `curl -s http://localhost:3000/solucoes | grep -oP '<title>.*?</title>'`
- `curl -s http://localhost:3000/contato | grep -oP '<title>.*?</title>'`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2b76d4832d861cbd4c85a2bbd0