### PR TITLE
Add comprehensive metadata to layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,23 @@ import WhatsappButton from '@/components/WhatsappButton';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://solarinvest.info'),
   title: 'SolarInvest Solutions',
   description: 'Energia solar inteligente e acessível.',
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: 'SolarInvest Solutions',
+    description: 'Energia solar inteligente e acessível.',
+    url: 'https://solarinvest.info',
+    images: ['/hero-solar-house.png'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SolarInvest Solutions',
+    description: 'Energia solar inteligente e acessível.',
+    images: ['/hero-solar-house.png'],
+  },
+  robots: { index: true, follow: true },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- enrich `metadata` with base URL, canonical link, Open Graph data, Twitter card, and robots directives
- ensure layout continues to declare Portuguese (Brazil) as the HTML language

## Testing
- `npm test` *(fails: Missing script "test" so no tests run)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2ab1d8832d8184365186b7fe9b