### PR TITLE
Fix sitemap domain and structure

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -1,20 +1,28 @@
-// src/app/sitemap.xml/route.ts
+// src/app/sitemap/route.ts
 
 export async function GET() {
+  const baseUrl = "https://solarinvest.info";
+
+  const routes = ["/", "/sobre", "/solucoes", "/contato", "/comofunciona"];
+
+  const urls = routes
+    .map(
+      (route) => `
+    <url>
+      <loc>${baseUrl}${route}</loc>
+      <lastmod>${new Date().toISOString()}</lastmod>
+    </url>`
+    )
+    .join("");
+
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-      <loc>https://solarinves.info/</loc>
-      <lastmod>${new Date().toISOString()}</lastmod>
-    </url>
-    <loc>https://solarinvest.com/</loc>
-    <loc>https://www.instagram.com/solarinvest.br/</loc>
-    
+  ${urls}
   </urlset>`;
 
   return new Response(sitemap, {
     headers: {
-      'Content-Type': 'application/xml',
+      "Content-Type": "application/xml",
     },
   });
 }


### PR DESCRIPTION
## Summary
- correct sitemap domain to `solarinvest.info`
- generate sitemap URLs dynamically and wrap each in `<url>`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2a4188832daec2049979a58b44