### PR TITLE
Rename robots file to txt and permit bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+Sitemap: https://solarinvest.info/sitemap.xml
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: GPTBot
+Allow: /

--- a/public/robots.xml
+++ b/public/robots.xml
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://solarinvest.info/sitemap.xml


### PR DESCRIPTION
## Summary
- rename `public/robots.xml` to `public/robots.txt`
- allow search engines and key bots, and add sitemap reference

## Testing
- `npm run lint`
- `curl -s http://localhost:3000/robots.txt`


------
https://chatgpt.com/codex/tasks/task_e_689d5a2a3e90832d91f8887e2b672296