### PR TITLE
feat: enable i18n locales

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,10 @@ const ContentSecurityPolicy = `
 `;
 
 module.exports = {
+  i18n: {
+    locales: ['pt-BR', 'en-US'],
+    defaultLocale: 'pt-BR',
+  },
   async headers() {
     return [
       {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,13 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'SolarInvest Solutions',
   description: 'Energia solar inteligente e acessível.',
+  alternates: {
+    canonical: '/',
+    languages: {
+      'pt-BR': '/',
+      'en-US': '/en-US',
+    },
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- enable Next.js i18n with `pt-BR` and `en-US`
- advertise locale versions via metadata `alternates` hrefLang

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5d16063c832da90a50d69ec03939