### PR TITLE
fix: refine sitemap generation

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -1,16 +1,15 @@
-// src/app/sitemap.xml/route.ts
-
 export async function GET() {
-  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
-  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-      <loc>https://solarinves.info/</loc>
-      <lastmod>${new Date().toISOString()}</lastmod>
-    </url>
-    <loc>https://solarinvest.com/</loc>
-    <loc>https://www.instagram.com/solarinvest.br/</loc>
-    
-  </urlset>`;
+  const baseUrl = 'https://solarinvest.info';
+  const lastMod = new Date().toISOString();
+  const pages = ['/', '/comofunciona', '/sobre', '/solucoes', '/contato'];
+
+  const urls = pages
+    .map(
+      (page) => `    <url>\n      <loc>${baseUrl}${page}</loc>\n      <lastmod>${lastMod}</lastmod>\n    </url>`,
+    )
+    .join('\n');
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n  </urlset>`;
 
   return new Response(sitemap, {
     headers: {
@@ -18,3 +17,4 @@ export async function GET() {
     },
   });
 }
+


### PR DESCRIPTION
## Summary
- include home and all public pages in sitemap
- ensure each page has its own `<url>` with `<loc>` and `<lastmod>`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689d5d14593c832d80639060b7ed614a