### PR TITLE
Add bilingual metadata to Solar Invest pages

### DIFF
--- a/src/app/comofunciona/page.tsx
+++ b/src/app/comofunciona/page.tsx
@@ -5,6 +5,23 @@
 import React from 'react';
 import ComoFunciona from '@/components/ComoFunciona';
 
+// 🔍 SEO Metadata
+export const metadata = {
+  title: 'Como Funciona | How It Works | Solar Invest Solutions',
+  description:
+    'Entenda como a Solar Invest Solutions oferece energia solar inteligente para economizar. Learn how Solar Invest Solutions delivers smart solar energy to save you money.',
+  keywords: [
+    'como funciona',
+    'how it works',
+    'energia solar',
+    'solar energy',
+    'economia de energia',
+    'energy savings',
+    'solar invest',
+    'solarinvest solutions',
+  ],
+};
+
 export default function ComoFuncionaPage() {
   return (
     <main className="min-h-screen bg-white">

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -3,6 +3,24 @@
 import { motion } from 'framer-motion';
 import ContatoForm from '@/components/ContatoForm';
 
+// 🔍 SEO Metadata
+export const metadata = {
+  title: 'Contato | Contact | Solar Invest Solutions',
+  description:
+    'Fale com a Solar Invest Solutions para conhecer nossas soluções solares. Get in touch with Solar Invest Solutions for solar energy solutions.',
+  keywords: [
+    'contato',
+    'contact',
+    'fale conosco',
+    'contact us',
+    'suporte',
+    'support',
+    'energia solar',
+    'solar energy',
+    'solar invest',
+  ],
+};
+
 export default function ContatoPage() {
   return (
     <main className="min-h-screen bg-white py-16 px-4 md:px-8">

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -2,6 +2,23 @@
 
 import { motion } from 'framer-motion';
 
+// 🔍 SEO Metadata
+export const metadata = {
+  title: 'Sobre Nós | About Us | Solar Invest Solutions',
+  description:
+    'Saiba mais sobre a Solar Invest Solutions e nosso compromisso com energia solar acessível. Learn about Solar Invest Solutions and our commitment to affordable solar energy.',
+  keywords: [
+    'sobre a solar invest',
+    'about solar invest',
+    'empresa de energia solar',
+    'solar energy company',
+    'missão',
+    'mission',
+    'energia sustentável',
+    'sustainable energy',
+  ],
+};
+
 export default function SobrePage() {
   return (
     <main className="min-h-screen bg-white py-16 px-4 md:px-8">

--- a/src/app/solucoes/page.tsx
+++ b/src/app/solucoes/page.tsx
@@ -2,6 +2,26 @@
 
 import { motion } from 'framer-motion';
 
+// 🔍 SEO Metadata
+export const metadata = {
+  title: 'Soluções | Solutions | Solar Invest Solutions',
+  description:
+    'Explore nossas soluções de energia solar para residências, negócios e áreas remotas. Explore our solar energy solutions for homes, businesses, and remote areas.',
+  keywords: [
+    'soluções solares',
+    'solar solutions',
+    'energia residencial',
+    'residential solar',
+    'energia comercial',
+    'commercial solar',
+    'off-grid',
+    'off grid',
+    'energia rural',
+    'rural solar',
+    'solar invest',
+  ],
+};
+
 export default function SolucoesPage() {
   return (
     <main className="min-h-screen bg-white py-16 px-4 md:px-8">


### PR DESCRIPTION
## Summary
- add SEO metadata (title, description, keywords) to `comofunciona`, `sobre`, `contato`, and `solucoes` pages
- include English translations to target US searches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d5d144044832d95676a359b88a0a0