### PR TITLE
fix: move client page metadata to server files

### DIFF
--- a/src/app/comofunciona/page.metadata.ts
+++ b/src/app/comofunciona/page.metadata.ts
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Como Funciona | How It Works | Solar Invest Solutions',
+  description:
+    'Entenda como a Solar Invest Solutions oferece energia solar inteligente para economizar. Learn how Solar Invest Solutions delivers smart solar energy to save you money.',
+};
+
+export default metadata;

--- a/src/app/contato/page.metadata.ts
+++ b/src/app/contato/page.metadata.ts
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Contato | Contact | Solar Invest Solutions',
+  description:
+    'Fale com a Solar Invest Solutions para conhecer nossas soluções solares. Get in touch with Solar Invest Solutions for solar energy solutions.',
+};
+
+export default metadata;

--- a/src/app/sobre/page.metadata.ts
+++ b/src/app/sobre/page.metadata.ts
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sobre Nós | About Us | Solar Invest Solutions',
+  description:
+    'Saiba mais sobre a Solar Invest Solutions e nosso compromisso com energia solar acessível. Learn about Solar Invest Solutions and our commitment to affordable solar energy.',
+};
+
+export default metadata;

--- a/src/app/solucoes/page.metadata.ts
+++ b/src/app/solucoes/page.metadata.ts
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Soluções | Solutions | Solar Invest Solutions',
+  description:
+    'Explore nossas soluções de energia solar para residências, negócios e áreas remotas. Explore our solar energy solutions for homes, businesses, and remote areas.',
+};
+
+export default metadata;


### PR DESCRIPTION
## Summary
- add server-side metadata modules for client-rendered pages to avoid `use client` export errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689d6015dbfc832d8eed98ca23757d18