### PR TITLE
feat: add basic search component and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Search and SEO
+
+A página `/search` oferece uma busca simples, alimentada pelo endpoint `/api/search`, que indexa as principais páginas do site. A página de busca inclui metadados de título e descrição para melhorar o SEO e facilitar que mecanismos de busca compreendam seu conteúdo.
+
+Para testar localmente:
+
+1. Execute `npm run dev`.
+2. Visite `http://localhost:3000/search`.
+3. Digite um termo como "soluções" para ver os resultados filtrados.
+

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+const pages = [
+  {
+    title: 'Sobre',
+    url: '/sobre',
+    description: 'Conheça a SolarInvest Solutions.',
+  },
+  {
+    title: 'Soluções',
+    url: '/solucoes',
+    description: 'Veja nossas soluções em energia solar.',
+  },
+  {
+    title: 'Contato',
+    url: '/contato',
+    description: 'Fale com a nossa equipe.',
+  },
+];
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q')?.toLowerCase() || '';
+
+  const results = pages.filter(
+    (page) =>
+      page.title.toLowerCase().includes(q) ||
+      page.description.toLowerCase().includes(q)
+  );
+
+  return NextResponse.json({ results });
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,17 @@
+import Search from '@/components/Search';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Busca | SolarInvest Solutions',
+  description:
+    'Use a busca para encontrar informações sobre energia solar e nossos serviços.',
+};
+
+export default function SearchPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-6">Buscar</h1>
+      <Search />
+    </main>
+  );
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Result {
+  title: string;
+  url: string;
+}
+
+export default function Search() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Result[]>([]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+
+    const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+    if (res.ok) {
+      const data = await res.json();
+      setResults(data.results);
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <form onSubmit={handleSubmit} className="flex gap-2" role="search">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar..."
+          aria-label="Buscar"
+          className="flex-grow border rounded px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="bg-orange-600 text-white px-4 py-2 rounded"
+        >
+          Buscar
+        </button>
+      </form>
+      <ul className="mt-4 space-y-2">
+        {results.map((r) => (
+          <li key={r.url}>
+            <a href={r.url} className="text-orange-600 hover:underline">
+              {r.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add search component and page
- provide API route for page search
- document search feature and SEO metadata

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d6d931600832d927789ba360fb417