### PR TITLE
Fix sitemap XML structure and domain

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -4,12 +4,15 @@ export async function GET() {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-      <loc>https://solarinves.info/</loc>
+      <loc>https://solarinvest.info/</loc>
       <lastmod>${new Date().toISOString()}</lastmod>
     </url>
-    <loc>https://solarinvest.com/</loc>
-    <loc>https://www.instagram.com/solarinvest.br/</loc>
-    
+    <url>
+      <loc>https://solarinvest.info/</loc>
+    </url>
+    <url>
+      <loc>https://www.instagram.com/solarinvest.br/</loc>
+    </url>
   </urlset>`;
 
   return new Response(sitemap, {


### PR DESCRIPTION
## Summary
- Wrap each `<loc>` entry in its own `<url>` block for valid sitemap structure
- Correct sitemap domain references to `https://solarinvest.info/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `<Document /> from next/document should not be imported outside of pages/_document.js`, `Component definition is missing display name`)*

------
https://chatgpt.com/codex/tasks/task_e_689d71267b88832db52bf916b34fbe8f