### PR TITLE
Add hero section id for anchor navigation

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,7 @@ const LiteYouTube = dynamic(() => import('@/components/LiteYouTube'), {
 
 export default function Hero() {
   return (
-    <section className="w-full bg-gradient-to-br from-yellow-50 to-orange-100 py-12 px-4">
+    <section id="hero" className="w-full bg-gradient-to-br from-yellow-50 to-orange-100 py-12 px-4">
       <div className="max-w-7xl mx-auto flex flex-col-reverse md:flex-row items-center justify-between gap-8">
 
         {/* 📢 Texto promocional do lado esquerdo */}


### PR DESCRIPTION
## Summary
- ensure hero section exposes `id="hero"` for anchor navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/Hero.tsx`
- `npm run lint` *(fails: `<Document /> from next/document should not be imported outside of pages/_document.js`)*
- `npm run build -- --no-lint` *(fails: Missing API key for Resend)*
- `node -e "const fs=require('fs');const header=fs.readFileSync('src/components/Header.tsx','utf8');console.log(/href=\\"\\/#hero\\"/.test(header));"`

------
https://chatgpt.com/codex/tasks/task_e_689d71b04dc8832db93284b9ef6d8a07