### PR TITLE
Add metadata for marketing pages

### DIFF
--- a/src/app/comofunciona/page.tsx
+++ b/src/app/comofunciona/page.tsx
@@ -1,9 +1,13 @@
 // src/app/comofunciona/page.tsx
 
-'use client';
-
 import React from 'react';
 import ComoFunciona from '@/components/ComoFunciona';
+
+export const metadata = {
+  title: 'Como Funciona | SolarInvest',
+  description:
+    'Entenda como a SolarInvest transforma sua conta de energia em economia com um processo simples e eficiente.',
+};
 
 export default function ComoFuncionaPage() {
   return (

--- a/src/app/contato/ClientPage.tsx
+++ b/src/app/contato/ClientPage.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import ContatoForm from '@/components/ContatoForm';
+
+export default function ContatoPageClient() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-3xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Fale com a gente
+        </motion.h1>
+
+        {/* 💬 Subtítulo animado */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-2xl mx-auto mb-10"
+        >
+          Está pronto para transformar sua energia em economia? Preencha o formulário abaixo e entraremos em contato rapidamente.
+        </motion.p>
+
+        {/* 📩 Formulário animado */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          <ContatoForm />
+        </motion.div>
+      </section>
+    </main>
+  );
+}
+

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -1,41 +1,11 @@
-'use client';
+import ContatoPageClient from './ClientPage';
 
-import { motion } from 'framer-motion';
-import ContatoForm from '@/components/ContatoForm';
+export const metadata = {
+  title: 'Contato | SolarInvest',
+  description: 'Fale com a equipe da SolarInvest e solicite sua análise gratuita de energia.',
+};
 
 export default function ContatoPage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-3xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Fale com a gente
-        </motion.h1>
-
-        {/* 💬 Subtítulo animado */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-2xl mx-auto mb-10"
-        >
-          Está pronto para transformar sua energia em economia? Preencha o formulário abaixo e entraremos em contato rapidamente.
-        </motion.p>
-
-        {/* 📩 Formulário animado */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-        >
-          <ContatoForm />
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <ContatoPageClient />;
 }
+

--- a/src/app/sobre/ClientPage.tsx
+++ b/src/app/sobre/ClientPage.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export default function SobrePageClient() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-5xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Sobre a SolarInvest
+        </motion.h1>
+
+        {/* 💬 Texto de introdução */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-3xl mx-auto mb-8"
+        >
+          A SolarInvest nasceu com o propósito de democratizar o acesso à energia solar no Brasil.
+          Nosso compromisso é oferecer soluções inteligentes, acessíveis e sustentáveis, permitindo que famílias e empresas economizem e contribuam para um futuro mais limpo.
+        </motion.p>
+
+        {/* ✅ Bloco institucional animado */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="bg-orange-50 rounded-xl shadow-md p-6 text-left mx-auto"
+        >
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Missão</h2>
+          <p className="text-gray-700 mb-4">
+            Tornar a energia solar uma realidade para todos, promovendo economia, autonomia energética e redução do impacto ambiental.
+          </p>
+
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Visão</h2>
+          <p className="text-gray-700 mb-4">
+            Ser referência em soluções fotovoltaicas no Brasil, com foco em inovação, transparência e excelência no atendimento.
+          </p>
+
+          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossos Valores</h2>
+          <ul className="list-disc list-inside text-gray-700 space-y-1">
+            <li>Transparência e ética em cada etapa</li>
+            <li>Compromisso com resultados reais</li>
+            <li>Respeito ao meio ambiente e às pessoas</li>
+            <li>Inovação constante e melhoria contínua</li>
+          </ul>
+        </motion.div>
+      </section>
+    </main>
+  );
+}
+

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,58 +1,11 @@
-'use client';
+import SobrePageClient from './ClientPage';
 
-import { motion } from 'framer-motion';
+export const metadata = {
+  title: 'Sobre a SolarInvest',
+  description: 'Conheça a missão, visão e valores da SolarInvest e nosso compromisso com a energia solar.',
+};
 
 export default function SobrePage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-5xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Sobre a SolarInvest
-        </motion.h1>
-
-        {/* 💬 Texto de introdução */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-3xl mx-auto mb-8"
-        >
-          A SolarInvest nasceu com o propósito de democratizar o acesso à energia solar no Brasil.
-          Nosso compromisso é oferecer soluções inteligentes, acessíveis e sustentáveis, permitindo que famílias e empresas economizem e contribuam para um futuro mais limpo.
-        </motion.p>
-
-        {/* ✅ Bloco institucional animado */}
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-          className="bg-orange-50 rounded-xl shadow-md p-6 text-left mx-auto"
-        >
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Missão</h2>
-          <p className="text-gray-700 mb-4">
-            Tornar a energia solar uma realidade para todos, promovendo economia, autonomia energética e redução do impacto ambiental.
-          </p>
-
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossa Visão</h2>
-          <p className="text-gray-700 mb-4">
-            Ser referência em soluções fotovoltaicas no Brasil, com foco em inovação, transparência e excelência no atendimento.
-          </p>
-
-          <h2 className="text-2xl font-bold text-orange-500 mb-4">Nossos Valores</h2>
-          <ul className="list-disc list-inside text-gray-700 space-y-1">
-            <li>Transparência e ética em cada etapa</li>
-            <li>Compromisso com resultados reais</li>
-            <li>Respeito ao meio ambiente e às pessoas</li>
-            <li>Inovação constante e melhoria contínua</li>
-          </ul>
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <SobrePageClient />;
 }
+

--- a/src/app/solucoes/ClientPage.tsx
+++ b/src/app/solucoes/ClientPage.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export default function SolucoesPageClient() {
+  return (
+    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
+      <section className="max-w-6xl mx-auto text-center">
+        {/* 🎯 Título com animação */}
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
+        >
+          Nossas Soluções
+        </motion.h1>
+
+        {/* 💬 Subtítulo animado */}
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="text-lg text-gray-700 max-w-2xl mx-auto mb-12"
+        >
+          Atendemos diferentes perfis de clientes com soluções solares personalizadas, eficientes e acessíveis para transformarsua relação com a energia.
+        </motion.p>
+
+        {/* 🧱 Cards animados */}
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-3 gap-12"
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+        >
+          {/* 🏠 Residencial */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Residencial</h2>
+            <p className="text-gray-700">
+              Energia solar para casas, apartamentos e condomínios. Reduza sua conta e invista em sustentabilidade com segurança e autonomia.
+            </p>
+          </div>
+
+          {/* 🏢 Comercial */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Comercial</h2>
+            <p className="text-gray-700">
+              Projetos para empresas e comércios que buscam economia, previsibilidade e valorização da marca com energia limpa.
+            </p>
+          </div>
+
+          {/* 🌱 Rural e Off-Grid */}
+          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
+            <h2 className="text-xl font-bold text-orange-500 mb-2">Rural e Off-Grid</h2>
+            <p className="text-gray-700">
+              Soluções completas para áreas remotas com energia contínua, mesmo sem acesso à rede elétrica tradicional.
+            </p>
+          </div>
+        </motion.div>
+      </section>
+    </main>
+  );
+}
+

--- a/src/app/solucoes/page.tsx
+++ b/src/app/solucoes/page.tsx
@@ -1,63 +1,11 @@
-'use client';
+import SolucoesPageClient from './ClientPage';
 
-import { motion } from 'framer-motion';
+export const metadata = {
+  title: 'Soluções | SolarInvest',
+  description: 'Explore as soluções de energia solar da SolarInvest para residências, empresas e áreas rurais.',
+};
 
 export default function SolucoesPage() {
-  return (
-    <main className="min-h-screen bg-white py-16 px-4 md:px-8">
-      <section className="max-w-6xl mx-auto text-center">
-        {/* 🎯 Título com animação */}
-        <motion.h1
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-heading font-bold text-orange-600 mb-6"
-        >
-          Nossas Soluções
-        </motion.h1>
-
-        {/* 💬 Subtítulo animado */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg text-gray-700 max-w-2xl mx-auto mb-12"
-        >
-          Atendemos diferentes perfis de clientes com soluções solares personalizadas, eficientes e acessíveis para transformar sua relação com a energia.
-        </motion.p>
-
-        {/* 🧱 Cards animados */}
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-3 gap-12"
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-        >
-          {/* 🏠 Residencial */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Residencial</h2>
-            <p className="text-gray-700">
-              Energia solar para casas, apartamentos e condomínios. Reduza sua conta e invista em sustentabilidade com segurança e autonomia.
-            </p>
-          </div>
-
-          {/* 🏢 Comercial */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Comercial</h2>
-            <p className="text-gray-700">
-              Projetos para empresas e comércios que buscam economia, previsibilidade e valorização da marca com energia limpa.
-            </p>
-          </div>
-
-          {/* 🌱 Rural e Off-Grid */}
-          <div className="bg-orange-50 rounded-xl p-6 shadow-md hover:shadow-lg transition-all text-left">
-            <h2 className="text-xl font-bold text-orange-500 mb-2">Rural e Off-Grid</h2>
-            <p className="text-gray-700">
-              Soluções completas para áreas remotas com energia contínua, mesmo sem acesso à rede elétrica tradicional.
-            </p>
-          </div>
-        </motion.div>
-      </section>
-    </main>
-  );
+  return <SolucoesPageClient />;
 }
+


### PR DESCRIPTION
## Summary
- add title/description metadata to Como Funciona, Contato, Sobre and Soluções pages
- refactor pages to server components with client-side wrappers so metadata works

## Testing
- `npm run lint` *(fails: `<Document />` imported outside pages directory; existing issue)*
- `npx eslint src/app/comofunciona/page.tsx src/app/contato/page.tsx src/app/contato/ClientPage.tsx src/app/sobre/page.tsx src/app/sobre/ClientPage.tsx src/app/solucoes/page.tsx src/app/solucoes/ClientPage.tsx`
- `npm run build` *(fails: missing API key for Resend in /api/contato)*
- `npm run dev` & `curl -s http://localhost:3000/comofunciona | grep -o '<title[^>]*>[^<]*</title>'`
- `curl -s http://localhost:3000/comofunciona | grep -o '<meta name="description" content="[^"]*"'`
- `curl -s http://localhost:3000/contato | grep -o '<title[^>]*>[^<]*</title>'`
- `curl -s http://localhost:3000/contato | grep -o '<meta name="description" content="[^"]*"'`
- `curl -s http://localhost:3000/sobre | grep -o '<title[^>]*>[^<]*</title>'`
- `curl -s http://localhost:3000/sobre | grep -o '<meta name="description" content="[^"]*"'`
- `curl -s http://localhost:3000/solucoes | grep -o '<title[^>]*>[^<]*</title>'`
- `curl -s http://localhost:3000/solucoes | grep -o '<meta name="description" content="[^"]*"'`


------
https://chatgpt.com/codex/tasks/task_e_689d71ad6780832da0aec2fd459c462e