### PR TITLE
chore: update site url to solarinvest.info

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import Script from 'next/script';
 
 import type { Metadata } from 'next';
 
-const siteUrl = 'https://solarinvest.com';
+const siteUrl = 'https://solarinvest.info';
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -1,14 +1,13 @@
 // Generates sitemap.xml
 
+const siteUrl = 'https://solarinvest.info';
+
 export async function GET() {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-      <loc>https://solarinvest.info/</loc>
+      <loc>${siteUrl}/</loc>
       <lastmod>${new Date().toISOString()}</lastmod>
-    </url>
-    <url>
-      <loc>https://solarinvest.com/</loc>
     </url>
     <url>
       <loc>https://www.instagram.com/solarinvest.br/</loc>


### PR DESCRIPTION
## Summary
- point siteUrl and structured data to https://solarinvest.info
- remove legacy solarinvest.com link from sitemap
- keep robots.txt and sitemap on the same canonical domain

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689d74f087c0832d9c0246ae11a8f217