### PR TITLE
Generate sitemap from centralized route list

### DIFF
--- a/src/app/sitemap/route.ts
+++ b/src/app/sitemap/route.ts
@@ -1,18 +1,21 @@
 // Generates sitemap.xml
+import { siteRoutes } from '@/routes';
+
+export const revalidate = 86400; // regenerate daily
 
 export async function GET() {
+  const baseUrl = 'https://solarinvest.info';
+  const lastmod = new Date().toISOString();
+  const urls = siteRoutes
+    .map((path) => `
+    <url>
+      <loc>${baseUrl}${path}</loc>
+      <lastmod>${lastmod}</lastmod>
+    </url>`)
+    .join('');
+
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
-  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-      <loc>https://solarinvest.info/</loc>
-      <lastmod>${new Date().toISOString()}</lastmod>
-    </url>
-    <url>
-      <loc>https://solarinvest.com/</loc>
-    </url>
-    <url>
-      <loc>https://www.instagram.com/solarinvest.br/</loc>
-    </url>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}
   </urlset>`;
 
   return new Response(sitemap, {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,8 @@
+export const siteRoutes = [
+  '/',
+  '/comofunciona',
+  '/solucoes',
+  '/sobre',
+  '/contato',
+  '/search',
+];


### PR DESCRIPTION
## Summary
- centralize site routes in `src/routes.ts`
- dynamically build sitemap from route list with `lastmod` tags
- enable daily regeneration via ISR

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_689d74f12f70832db0a0550d3d1a9209