### PR TITLE
Restaurar logo original na homepage

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 export default function Header() {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [logoSrc, setLogoSrc] = useState('/logos_festivos/2026_Logo.png');
+  const [logoSrc, setLogoSrc] = useState('/icon.png');
 
   const handleLogoError = () => {
     setLogoSrc((current) => (current === '/icon.png' ? current : '/icon.png'));
@@ -44,7 +44,7 @@ export default function Header() {
         >
           <Image
             src={logoSrc}
-            alt="Logo comemorativo da SolarInvest"
+            alt="Logo original da SolarInvest"
             width={64}
             height={64}
             className="w-16 h-16 object-contain"

--- a/src/components/HomeWithSplash.tsx
+++ b/src/components/HomeWithSplash.tsx
@@ -9,7 +9,7 @@ import Hero from './Hero';
 
 export default function HomeWithSplash() {
   const [showSplash, setShowSplash] = useState(true);
-  const [splashSrc, setSplashSrc] = useState('/splash_festivos/Feliz_2026.png');
+  const [splashSrc, setSplashSrc] = useState('/icon.png');
   const splashCooldownMs = 5 * 60 * 1000;
   const splashStorageKey = 'solarinvest:splash:lastShown';
 
@@ -39,7 +39,7 @@ export default function HomeWithSplash() {
           <div className="rounded-3xl border border-orange-200/70 bg-white/80 p-6 shadow-[0_25px_55px_-30px_rgba(249,115,22,0.45)] backdrop-blur-sm">
             <Image
               src={splashSrc}
-              alt="Logotipo comemorativo da SolarInvest"
+              alt="Logo original da SolarInvest"
               width={320}
               height={320}
               priority

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 
 export default function SplashScreen({ children }: { children: React.ReactNode }) {
   const [showSplash, setShowSplash] = useState(true);
-  const [splashSrc, setSplashSrc] = useState('/splash_festivos/Feliz_2026.png');
+  const [splashSrc, setSplashSrc] = useState('/icon.png');
   const splashCooldownMs = 5 * 60 * 1000;
   const splashStorageKey = 'solarinvest:splash:lastShown';
 
@@ -35,7 +35,7 @@ export default function SplashScreen({ children }: { children: React.ReactNode }
           <div className="flex items-center justify-center p-6">
             <Image
               src={splashSrc}
-              alt="SolarInvest"
+              alt="Logo original da SolarInvest"
               width={360}
               height={360}
               priority

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 const siteUrl = 'https://solarinvest.info';
 const siteName = 'SolarInvest';
-const logoPath = '/logos_festivos/2026_Logo.png';
+const logoPath = '/icon.png';
 const logoUrl = `${siteUrl}${logoPath}`;
 const defaultImage = `${siteUrl}/favicon.png`;
 const baseKeywords = [


### PR DESCRIPTION
### Motivation
- Repor a marca original da SolarInvest no header e no splash/hero para substituir a logo comemorativa de ano novo e manter a identidade visual padrão.

### Description
- Em `src/components/Header.tsx` alterei `logoSrc` de `/logos_festivos/2026_Logo.png` para `/icon.png` e atualizei o `alt` para `Logo original da SolarInvest`.
- Em `src/components/HomeWithSplash.tsx` alterei `splashSrc` de `/splash_festivos/Feliz_2026.png` para `/icon.png` e atualizei o `alt` para `Logo original da SolarInvest`.
- As rotinas de fallback de imagem (`onError`) foram preservadas para apontar para `/icon.png` sem outras mudanças de comportamento.

### Testing
- Executei `npm test`, que finalizou com sucesso (saída: "No tests specified").
- Executei `npm run lint`, que concluiu com sucesso e sem avisos (`No ESLint warnings or errors`).
- Executei `git diff --check`, sem sinalizar problemas.
- Tentei capturar uma captura de tela automatizada usando Playwright via `npx playwright`, mas a instalação/execução falhou devido à indisponibilidade do pacote no registro (`403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a327b22ca348331959c2091153f3576)