### PR TITLE
Ajusta largura da Área do Cliente

### DIFF
--- a/src/app/area-do-cliente/limpeza-modulos/page.tsx
+++ b/src/app/area-do-cliente/limpeza-modulos/page.tsx
@@ -62,8 +62,8 @@ export default function Page() {
       title="Manual de Limpeza dos Módulos"
       description="Orientações detalhadas para limpar módulos fotovoltaicos com segurança, preservando geração, garantia e integridade da usina. A limpeza parece simples, mas envolve eletricidade, altura e risco de dano ao equipamento quando feita de forma incorreta."
     >
-      <div className="mt-10 grid gap-8 lg:grid-cols-[1fr_340px]">
-        <article className="space-y-8 text-slate-700">
+      <div className="mt-10 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <article className="min-w-0 space-y-8 text-slate-700">
           <section className="rounded-3xl border border-orange-100 bg-orange-50 p-6 shadow-sm">
             <div className="flex gap-4">
               <ShieldAlert className="mt-1 h-7 w-7 flex-none text-orange-600" aria-hidden="true" />
@@ -76,14 +76,15 @@ export default function Page() {
             </div>
           </section>
 
-          <section className="rounded-3xl bg-white p-8 shadow-sm">
-            <h2 className="text-2xl font-black text-slate-900">Quando limpar</h2>
-            <p className="mt-3 leading-relaxed">
-              Limpe quando houver acúmulo visível de poeira, fezes de pássaros, folhas, poluição, maresia, fuligem ou fumaça, especialmente se a geração cair em relação ao histórico. A recomendação operacional é fazer inspeção visual mensal e comparar a geração no aplicativo de monitoramento antes de decidir pela limpeza.
-            </p>
-          </section>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <section className="rounded-3xl bg-white p-8 shadow-sm">
+              <h2 className="text-2xl font-black text-slate-900">Quando limpar</h2>
+              <p className="mt-3 leading-relaxed">
+                Limpe quando houver acúmulo visível de poeira, fezes de pássaros, folhas, poluição, maresia, fuligem ou fumaça, especialmente se a geração cair em relação ao histórico. A recomendação operacional é fazer inspeção visual mensal e comparar a geração no aplicativo de monitoramento antes de decidir pela limpeza.
+              </p>
+            </section>
 
-          <section id="frequencia" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="frequencia" className="rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Frequência recomendada</h2>
             <p className="mt-3 leading-relaxed">
               A frequência depende do nível de sujeira, inclinação dos módulos, período de chuvas e exposição local. Não existe um intervalo único para todos os sistemas: use a tabela como referência e ajuste com base na inspeção visual e no desempenho real da usina.
@@ -96,16 +97,18 @@ export default function Page() {
                 </div>
               ))}
             </div>
-          </section>
+            </section>
+          </div>
 
-          <section className="rounded-3xl bg-white p-8 shadow-sm">
-            <h2 className="text-2xl font-black text-slate-900">Horário correto</h2>
-            <p className="mt-3 leading-relaxed">
-              Realize a limpeza no início da manhã ou no final da tarde, quando os módulos estão mais frios e a irradiância é menor. Nunca limpe sob sol forte ou com módulos muito quentes: a água fria sobre vidro aquecido pode provocar choque térmico, além de aumentar risco de queimadura, desidratação e queda durante o trabalho.
-            </p>
-          </section>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <section className="rounded-3xl bg-white p-8 shadow-sm">
+              <h2 className="text-2xl font-black text-slate-900">Horário correto</h2>
+              <p className="mt-3 leading-relaxed">
+                Realize a limpeza no início da manhã ou no final da tarde, quando os módulos estão mais frios e a irradiância é menor. Nunca limpe sob sol forte ou com módulos muito quentes: a água fria sobre vidro aquecido pode provocar choque térmico, além de aumentar risco de queimadura, desidratação e queda durante o trabalho.
+              </p>
+            </section>
 
-          <section id="materiais" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="materiais" className="rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Materiais permitidos</h2>
             <ul className="mt-4 grid gap-3 sm:grid-cols-2">
               <li>✓ água limpa em temperatura ambiente</li>
@@ -115,9 +118,9 @@ export default function Page() {
               <li>✓ escova macia de cerdas não metálicas</li>
               <li>✓ rodo apropriado com borracha macia</li>
             </ul>
-          </section>
+            </section>
 
-          <section id="proibido" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="proibido" className="rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Proibido utilizar</h2>
             <ul className="mt-4 grid gap-3 sm:grid-cols-2">
               <li>✗ lavadora de alta pressão</li>
@@ -127,11 +130,12 @@ export default function Page() {
               <li>✗ escovas metálicas ou palha de aço</li>
               <li>✗ objetos cortantes ou raspadores rígidos</li>
             </ul>
-          </section>
+            </section>
+          </div>
 
           <section className="rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Passo a passo detalhado</h2>
-            <div className="mt-6 space-y-4">
+            <div className="mt-6 grid grid-cols-1 gap-5 lg:grid-cols-2">
               {steps.map((step, index) => (
                 <div key={step.title} className="rounded-2xl border border-slate-100 bg-slate-50 p-5">
                   <span className="text-xs font-black uppercase tracking-[0.2em] text-orange-600">Passo {index + 1}</span>

--- a/src/app/area-do-cliente/limpeza-modulos/page.tsx
+++ b/src/app/area-do-cliente/limpeza-modulos/page.tsx
@@ -100,15 +100,15 @@ export default function Page() {
             </section>
           </div>
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            <section className="rounded-3xl bg-white p-8 shadow-sm">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <section className="h-full rounded-3xl bg-white p-8 shadow-sm">
               <h2 className="text-2xl font-black text-slate-900">Horário correto</h2>
               <p className="mt-3 leading-relaxed">
                 Realize a limpeza no início da manhã ou no final da tarde, quando os módulos estão mais frios e a irradiância é menor. Nunca limpe sob sol forte ou com módulos muito quentes: a água fria sobre vidro aquecido pode provocar choque térmico, além de aumentar risco de queimadura, desidratação e queda durante o trabalho.
               </p>
             </section>
 
-            <section id="materiais" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="materiais" className="h-full rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Materiais permitidos</h2>
             <ul className="mt-4 grid gap-3 sm:grid-cols-2">
               <li>✓ água limpa em temperatura ambiente</li>
@@ -120,7 +120,7 @@ export default function Page() {
             </ul>
             </section>
 
-            <section id="proibido" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="proibido" className="h-full rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Proibido utilizar</h2>
             <ul className="mt-4 grid gap-3 sm:grid-cols-2">
               <li>✗ lavadora de alta pressão</li>
@@ -130,6 +130,22 @@ export default function Page() {
               <li>✗ escovas metálicas ou palha de aço</li>
               <li>✗ objetos cortantes ou raspadores rígidos</li>
             </ul>
+            </section>
+
+            <section className="h-full rounded-3xl bg-white p-8 shadow-sm">
+              <h2 className="text-2xl font-black text-slate-900">Sinais de alerta</h2>
+              <p className="mt-3 leading-relaxed">
+                Se qualquer item abaixo for identificado, não continue a limpeza. Interrompa o procedimento, mantenha distância de partes elétricas e solicite inspeção técnica.
+              </p>
+              <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                <span>□ vidro quebrado</span>
+                <span>□ manchas permanentes</span>
+                <span>□ delaminação</span>
+                <span>□ pontos quentes aparentes</span>
+                <span>□ cabos expostos</span>
+                <span>□ conectores danificados</span>
+              </div>
+              <div className="mt-6"><SupportCta /></div>
             </section>
           </div>
 
@@ -151,22 +167,6 @@ export default function Page() {
             <p className="mt-3 leading-relaxed">
               Há risco de queda, choque elétrico, queimaduras e dano permanente aos equipamentos. Trabalho em telhados exige planejamento, isolamento da área, EPIs adequados e capacitação compatível com NR-35 quando houver trabalho em altura. Se não houver treinamento, ponto de ancoragem, acesso seguro ou conhecimento elétrico mínimo, contrate empresa especializada.
             </p>
-          </section>
-
-          <section className="rounded-3xl bg-white p-8 shadow-sm">
-            <h2 className="text-2xl font-black text-slate-900">Sinais de alerta</h2>
-            <p className="mt-3 leading-relaxed">
-              Se qualquer item abaixo for identificado, não continue a limpeza. Interrompa o procedimento, mantenha distância de partes elétricas e solicite inspeção técnica.
-            </p>
-            <div className="mt-4 grid gap-2 sm:grid-cols-2">
-              <span>□ vidro quebrado</span>
-              <span>□ manchas permanentes</span>
-              <span>□ delaminação</span>
-              <span>□ pontos quentes aparentes</span>
-              <span>□ cabos expostos</span>
-              <span>□ conectores danificados</span>
-            </div>
-            <div className="mt-6"><SupportCta /></div>
           </section>
         </article>
 

--- a/src/app/area-do-cliente/limpeza-modulos/page.tsx
+++ b/src/app/area-do-cliente/limpeza-modulos/page.tsx
@@ -62,7 +62,7 @@ export default function Page() {
       title="Manual de Limpeza dos Módulos"
       description="Orientações detalhadas para limpar módulos fotovoltaicos com segurança, preservando geração, garantia e integridade da usina. A limpeza parece simples, mas envolve eletricidade, altura e risco de dano ao equipamento quando feita de forma incorreta."
     >
-      <div className="mt-10 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="mt-10 grid grid-cols-1 gap-8 xl:grid-cols-[minmax(0,900px)_320px] 2xl:grid-cols-[minmax(0,960px)_340px]">
         <article className="min-w-0 space-y-8 text-slate-700">
           <section className="rounded-3xl border border-orange-100 bg-orange-50 p-6 shadow-sm">
             <div className="flex gap-4">
@@ -77,14 +77,14 @@ export default function Page() {
           </section>
 
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            <section className="rounded-3xl bg-white p-8 shadow-sm">
+            <section className="col-span-1 rounded-3xl bg-white p-8 shadow-sm lg:col-span-2">
               <h2 className="text-2xl font-black text-slate-900">Quando limpar</h2>
               <p className="mt-3 leading-relaxed">
                 Limpe quando houver acúmulo visível de poeira, fezes de pássaros, folhas, poluição, maresia, fuligem ou fumaça, especialmente se a geração cair em relação ao histórico. A recomendação operacional é fazer inspeção visual mensal e comparar a geração no aplicativo de monitoramento antes de decidir pela limpeza.
               </p>
             </section>
 
-            <section id="frequencia" className="rounded-3xl bg-white p-8 shadow-sm">
+            <section id="frequencia" className="col-span-1 rounded-3xl bg-white p-8 shadow-sm lg:col-span-2">
             <h2 className="text-2xl font-black text-slate-900">Frequência recomendada</h2>
             <p className="mt-3 leading-relaxed">
               A frequência depende do nível de sujeira, inclinação dos módulos, período de chuvas e exposição local. Não existe um intervalo único para todos os sistemas: use a tabela como referência e ajuste com base na inspeção visual e no desempenho real da usina.
@@ -135,7 +135,7 @@ export default function Page() {
 
           <section className="rounded-3xl bg-white p-8 shadow-sm">
             <h2 className="text-2xl font-black text-slate-900">Passo a passo detalhado</h2>
-            <div className="mt-6 grid grid-cols-1 gap-5 lg:grid-cols-2">
+            <div className="mt-6 grid grid-cols-1 gap-5 2xl:grid-cols-2">
               {steps.map((step, index) => (
                 <div key={step.title} className="rounded-2xl border border-slate-100 bg-slate-50 p-5">
                   <span className="text-xs font-black uppercase tracking-[0.2em] text-orange-600">Passo {index + 1}</span>
@@ -170,7 +170,7 @@ export default function Page() {
           </section>
         </article>
 
-        <aside className="h-fit space-y-5">
+        <aside className="space-y-5 xl:sticky xl:top-28 xl:self-start">
           <div className="rounded-3xl bg-orange-50 p-6 shadow-sm">
             <h2 className="font-black text-slate-900">Resumo rápido</h2>
             <p className="mt-2 text-sm leading-relaxed text-slate-700">

--- a/src/app/area-do-cliente/page.tsx
+++ b/src/app/area-do-cliente/page.tsx
@@ -38,7 +38,7 @@ export default function AreaDoClientePage() {
       <section className="pb-8 pt-5">
         <div className={clientAreaContainerClass}>
           <Breadcrumbs items={[{ label: 'Área do Cliente' }]} compact />
-          <div className="grid gap-8 rounded-[2rem] border border-orange-100 bg-white/90 p-6 shadow-xl shadow-orange-100/60 md:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
+          <div className="grid gap-8 rounded-3xl border border-orange-100 bg-white/90 p-6 shadow-xl shadow-orange-100/60 md:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
             <div className="py-2">
               <span className="inline-flex rounded-full bg-orange-100 px-4 py-2 text-sm font-bold uppercase tracking-[0.2em] text-orange-700">
                 Área do Cliente
@@ -81,7 +81,7 @@ export default function AreaDoClientePage() {
               Cards compactos para encontrar qualquer orientação em poucos cliques, sem excesso de rolagem.
             </p>
           </div>
-          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {categories.map((cat) => {
               const Icon = cat.icon;
               return (
@@ -100,22 +100,24 @@ export default function AreaDoClientePage() {
       </section>
 
       <section id="downloads" className="py-8">
-        <div className={`${clientAreaContainerClass} rounded-[2rem] border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-white p-6 shadow-lg shadow-orange-100/50 md:p-8`}>
-          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div className={clientAreaContainerClass}>
+          <div className="rounded-3xl border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-white p-6 shadow-lg shadow-orange-100/50 md:p-8">
+            <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div>
               <span className="text-sm font-black uppercase tracking-[0.2em] text-orange-600">Biblioteca</span>
               <h2 className="mt-2 text-3xl font-black text-slate-900">Documentação e downloads</h2>
             </div>
             <p className="max-w-xl text-sm text-slate-600">Estrutura preparada para anexar PDFs e versões futuras dos materiais técnicos.</p>
           </div>
-          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
-            {downloads.map((item) => (
-              <div key={item} className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm">
-                <Download className="h-6 w-6 text-orange-500" aria-hidden="true" />
-                <h3 className="mt-3 font-bold text-slate-900">{item}</h3>
-                <p className="mt-2 text-sm text-slate-600">PDF em preparação</p>
-              </div>
-            ))}
+            <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+              {downloads.map((item) => (
+                <div key={item} className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm">
+                  <Download className="h-6 w-6 text-orange-500" aria-hidden="true" />
+                  <h3 className="mt-3 font-bold text-slate-900">{item}</h3>
+                  <p className="mt-2 text-sm text-slate-600">PDF em preparação</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>

--- a/src/app/area-do-cliente/page.tsx
+++ b/src/app/area-do-cliente/page.tsx
@@ -4,7 +4,7 @@ import { buildMetadata } from '@/lib/seo';
 import ClientAreaSearch from '@/components/cliente/ClientAreaSearch';
 import ClientFAQ from '@/components/cliente/ClientFAQ';
 import { categories, downloads, faqs } from '@/components/cliente/ClientAreaData';
-import { Breadcrumbs, JsonLd } from '@/components/cliente/ClientAreaLayout';
+import { Breadcrumbs, JsonLd, clientAreaContainerClass } from '@/components/cliente/ClientAreaLayout';
 
 export const metadata = buildMetadata({
   title: 'Central do Cliente SolarInvest | Manutenção, Limpeza e Garantias',
@@ -35,8 +35,8 @@ export default function AreaDoClientePage() {
     <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-24">
       <JsonLd id="client-faq-jsonld" data={faqJsonLd} />
 
-      <section className="px-6 pb-8 pt-5 md:px-16 lg:px-28">
-        <div className="mx-auto max-w-7xl">
+      <section className="pb-8 pt-5">
+        <div className={clientAreaContainerClass}>
           <Breadcrumbs items={[{ label: 'Área do Cliente' }]} compact />
           <div className="grid gap-8 rounded-[2rem] border border-orange-100 bg-white/90 p-6 shadow-xl shadow-orange-100/60 md:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
             <div className="py-2">
@@ -70,8 +70,8 @@ export default function AreaDoClientePage() {
         </div>
       </section>
 
-      <section className="px-6 py-8 md:px-16 lg:px-28">
-        <div className="mx-auto max-w-7xl">
+      <section className="py-8">
+        <div className={clientAreaContainerClass}>
           <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div>
               <span className="text-sm font-black uppercase tracking-[0.2em] text-orange-600">Navegação rápida</span>
@@ -99,8 +99,8 @@ export default function AreaDoClientePage() {
         </div>
       </section>
 
-      <section id="downloads" className="px-6 py-8 md:px-16 lg:px-28">
-        <div className="mx-auto max-w-7xl rounded-[2rem] border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-white p-6 shadow-lg shadow-orange-100/50 md:p-8">
+      <section id="downloads" className="py-8">
+        <div className={`${clientAreaContainerClass} rounded-[2rem] border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-white p-6 shadow-lg shadow-orange-100/50 md:p-8`}>
           <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div>
               <span className="text-sm font-black uppercase tracking-[0.2em] text-orange-600">Biblioteca</span>
@@ -120,8 +120,8 @@ export default function AreaDoClientePage() {
         </div>
       </section>
 
-      <section id="faq" className="px-6 pb-14 pt-8 md:px-16 lg:px-28">
-        <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[320px_1fr]">
+      <section id="faq" className="pb-14 pt-8">
+        <div className={`${clientAreaContainerClass} grid gap-8 lg:grid-cols-[320px_1fr]`}>
           <div className="rounded-3xl border border-orange-100 bg-orange-50 p-6 lg:h-fit">
             <FileText className="h-8 w-8 text-orange-500" aria-hidden="true" />
             <h2 className="mt-4 text-3xl font-black text-slate-900">FAQ inteligente</h2>

--- a/src/app/area-do-cliente/page.tsx
+++ b/src/app/area-do-cliente/page.tsx
@@ -4,7 +4,7 @@ import { buildMetadata } from '@/lib/seo';
 import ClientAreaSearch from '@/components/cliente/ClientAreaSearch';
 import ClientFAQ from '@/components/cliente/ClientFAQ';
 import { categories, downloads, faqs } from '@/components/cliente/ClientAreaData';
-import { Breadcrumbs, JsonLd, clientAreaContainerClass } from '@/components/cliente/ClientAreaLayout';
+import { JsonLd, clientAreaContainerClass } from '@/components/cliente/ClientAreaLayout';
 
 export const metadata = buildMetadata({
   title: 'Central do Cliente SolarInvest | Manutenção, Limpeza e Garantias',
@@ -32,12 +32,11 @@ export default function AreaDoClientePage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-24">
+    <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-12">
       <JsonLd id="client-faq-jsonld" data={faqJsonLd} />
 
-      <section className="pb-8 pt-5">
+      <section className="pb-8">
         <div className={clientAreaContainerClass}>
-          <Breadcrumbs items={[{ label: 'Área do Cliente' }]} compact />
           <div className="grid gap-8 rounded-3xl border border-orange-100 bg-white/90 p-6 shadow-xl shadow-orange-100/60 md:p-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
             <div className="py-2">
               <span className="inline-flex rounded-full bg-orange-100 px-4 py-2 text-sm font-bold uppercase tracking-[0.2em] text-orange-700">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,77 +1,153 @@
 'use client';
 
 import Link from 'next/link';
-import { FaWhatsapp, FaInstagram, FaLinkedin, FaFacebook } from 'react-icons/fa';
+import { FaFacebook, FaInstagram, FaLinkedin, FaWhatsapp } from 'react-icons/fa';
+
+const navigationLinks = [
+  { label: 'Início', href: '/' },
+  { label: 'Como Funciona', href: '/comofunciona' },
+  { label: 'Soluções', href: '/solucoes' },
+  { label: 'Vídeos', href: '/videos' },
+  { label: 'Sobre', href: '/sobre' },
+  { label: 'Contato', href: '/contato' },
+];
+
+const clientLinks = [
+  { label: 'Manual de Limpeza', href: '/area-do-cliente/limpeza-modulos' },
+  { label: 'Garantias', href: '/area-do-cliente/garantias' },
+  { label: 'Manutenção Preventiva', href: '/area-do-cliente/planos' },
+  { label: 'Inversores', href: '/area-do-cliente/inversores' },
+  { label: 'Suporte Técnico', href: '/area-do-cliente/suporte' },
+  { label: 'Planos de O&M', href: '/area-do-cliente/planos' },
+];
+
+const socialLinks = [
+  {
+    label: 'WhatsApp oficial SolarInvest',
+    href: 'https://api.whatsapp.com/send/?phone=5562995150975&text=Ol%C3%A1%21+Gostaria+de+saber+mais+sobre+a+energia+solar+da+SolarInvest.&type=phone_number&app_absent=0',
+    icon: FaWhatsapp,
+    className: 'text-green-400 hover:text-green-300',
+  },
+  {
+    label: 'Instagram oficial SolarInvest',
+    href: 'https://www.instagram.com/solarinvest.br/',
+    icon: FaInstagram,
+    className: 'text-pink-400 hover:text-pink-300',
+  },
+  {
+    label: 'Facebook oficial SolarInvest',
+    href: 'https://www.facebook.com/SolarInvestSolutions',
+    icon: FaFacebook,
+    className: 'text-blue-500 hover:text-blue-400',
+  },
+  {
+    label: 'LinkedIn oficial SolarInvest',
+    href: 'https://www.linkedin.com/company/solarinvest-solutions',
+    icon: FaLinkedin,
+    className: 'text-blue-400 hover:text-blue-300',
+  },
+];
+
+function FooterHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-sm font-black uppercase tracking-[0.22em] text-orange-400">
+      {children}
+    </h2>
+  );
+}
+
+function FooterLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link href={href} className="text-sm text-slate-300 transition hover:text-orange-300">
+      {children}
+    </Link>
+  );
+}
 
 export default function Footer() {
   return (
-    <footer className="bg-[#0B1622] text-gray-300 pt-12 pb-8 px-4">
-      <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-10">
+    <footer className="bg-[#0B1622] px-4 py-12 text-slate-300 sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-4 lg:gap-8">
+        <div className="space-y-5">
+          <div>
+            <p className="text-2xl font-black text-orange-500">SolarInvest</p>
+            <p className="mt-1 text-sm font-semibold text-slate-400">
+              da economia mensal ao patrimônio real
+            </p>
+          </div>
+          <p className="max-w-sm text-sm leading-relaxed text-slate-400">
+            Transformando economia mensal em patrimônio real através de soluções inteligentes de energia solar.
+          </p>
+          <div className="flex items-center gap-4">
+            {socialLinks.map(({ label, href, icon: Icon, className }) => (
+              <a
+                key={label}
+                href={href}
+                target="_blank"
+                rel="me noopener noreferrer"
+                aria-label={label}
+                className={`${className} transition`}
+              >
+                <span className="sr-only">{label}</span>
+                <Icon size={23} aria-hidden="true" />
+              </a>
+            ))}
+          </div>
+        </div>
 
-        {/* 🔆 Descrição da empresa */}
+        <nav className="space-y-4" aria-label="Navegação do rodapé">
+          <FooterHeading>Navegação</FooterHeading>
+          <div className="flex flex-col gap-3">
+            {navigationLinks.map((link) => (
+              <FooterLink key={link.href} href={link.href}>
+                {link.label}
+              </FooterLink>
+            ))}
+          </div>
+        </nav>
+
+        <nav className="space-y-4" aria-label="Central do Cliente no rodapé">
+          <FooterHeading>Central do Cliente</FooterHeading>
+          <div className="flex flex-col gap-3">
+            {clientLinks.map((link) => (
+              <FooterLink key={`${link.href}-${link.label}`} href={link.href}>
+                {link.label}
+              </FooterLink>
+            ))}
+          </div>
+        </nav>
+
         <div className="space-y-4">
-          <h2 className="text-2xl font-bold text-orange-500">SolarInvest</h2>
-          <p className="text-sm leading-relaxed max-w-sm">
-            Soluções inteligentes em energia solar para residências, condomínios e pequenas empresas.
-          </p>
-          <p className="text-sm text-gray-400">
-            Cidade: Anápolis – GO<br />
-            Tel:(62) 99515-0975
-          </p>
-        </div>
-
-        {/* 🔗 Links de navegação */}
-        <div className="flex flex-col space-y-2 text-sm">
-          <Link href="/" className="hover:text-orange-400 transition">Início</Link>
-          <Link href="/solucoes" className="hover:text-orange-400 transition">Soluções</Link>
-          <Link href="/videos" className="hover:text-orange-400 transition">Vídeos</Link>
-          <Link href="/sobre" className="hover:text-orange-400 transition">Sobre</Link>
-          <Link href="/contato" className="hover:text-orange-400 transition">Contato</Link>
-        </div>
-
-        {/* 🌐 Redes sociais com ícones coloridos */}
-        <div className="flex items-start md:justify-end space-x-6 pt-1">
-          <a
-            href="https://api.whatsapp.com/send/?phone=5562995150975&text=Ol%C3%A1%21+Gostaria+de+saber+mais+sobre+a+energia+solar+da+SolarInvest.&type=phone_number&app_absent=0"
-            target="_blank"
-            rel="me noopener noreferrer"
-            aria-label="WhatsApp"
-          >
-            <span className="sr-only">WhatsApp oficial SolarInvest</span>
-            <FaWhatsapp size={24} className="text-green-400 hover:text-green-300 transition" />
-          </a>
-          <a
-            href="https://www.instagram.com/solarinvest.br/"
-            target="_blank"
-            rel="me noopener noreferrer"
-            aria-label="Instagram"
-          >
-            <span className="sr-only">Instagram oficial SolarInvest</span>
-            <FaInstagram size={24} className="text-pink-400 hover:text-pink-300 transition" />
-          </a>
-          <a
-            href="https://www.facebook.com/SolarInvestSolutions"
-            target="_blank"
-            rel="me noopener noreferrer"
-            aria-label="Facebook"
-          >
-            <span className="sr-only">Facebook oficial SolarInvest</span>
-            <FaFacebook size={24} className="text-blue-500 hover:text-blue-400 transition" />
-          </a>
-          <a
-            href="https://www.linkedin.com/company/solarinvest-solutions"
-            target="_blank"
-            rel="me noopener noreferrer"
-            aria-label="LinkedIn"
-          >
-            <span className="sr-only">LinkedIn oficial SolarInvest</span>
-            <FaLinkedin size={24} className="text-blue-400 hover:text-blue-300 transition" />
-          </a>
+          <FooterHeading>Contato</FooterHeading>
+          <address className="not-italic text-sm leading-7 text-slate-400">
+            <p>
+              <span className="font-semibold text-slate-200">Telefone:</span> (62) 99515-0975
+            </p>
+            <p>
+              <span className="font-semibold text-slate-200">WhatsApp:</span>{' '}
+              <a
+                href="https://api.whatsapp.com/send/?phone=5562995150975&text=Ol%C3%A1%21+Gostaria+de+saber+mais+sobre+a+energia+solar+da+SolarInvest.&type=phone_number&app_absent=0"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="transition hover:text-orange-300"
+              >
+                (62) 99515-0975
+              </a>
+            </p>
+            <p>
+              <span className="font-semibold text-slate-200">E-mail:</span>{' '}
+              <a href="mailto:contato@solarinvest.info" className="transition hover:text-orange-300">
+                contato@solarinvest.info
+              </a>
+            </p>
+            <p>
+              <span className="font-semibold text-slate-200">Cidade/Estado:</span> Anápolis – GO
+            </p>
+          </address>
         </div>
       </div>
 
-      {/* 📌 Rodapé inferior */}
-      <div className="mt-10 border-t border-gray-800 pt-4 text-center text-xs text-gray-500">
+      <div className="mx-auto mt-10 max-w-7xl border-t border-slate-800 pt-5 text-center text-xs text-slate-500">
         © {new Date().getFullYear()} SolarInvest. Todos os direitos reservados.
       </div>
     </footer>

--- a/src/components/cliente/ClientAreaLayout.tsx
+++ b/src/components/cliente/ClientAreaLayout.tsx
@@ -26,10 +26,9 @@ export const clientAreaContainerClass = 'mx-auto w-full max-w-[1320px] px-4 sm:p
 
 export function PageShell({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
   return (
-    <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-24">
-      <section className="pb-12 pt-5">
+    <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-12">
+      <section className="pb-12">
         <div className={clientAreaContainerClass}>
-          <Breadcrumbs items={[{ label: 'Área do Cliente', href: '/area-do-cliente' }, { label: title }]} />
           <div className="overflow-hidden rounded-3xl border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-50 p-6 text-slate-900 shadow-xl shadow-orange-100/60 md:p-8">
             <div className="w-full">
               <span className="inline-flex rounded-full bg-orange-100 px-4 py-2 text-sm font-bold uppercase tracking-[0.2em] text-orange-700">

--- a/src/components/cliente/ClientAreaLayout.tsx
+++ b/src/components/cliente/ClientAreaLayout.tsx
@@ -22,14 +22,16 @@ export function Breadcrumbs({ items, compact = false }: { items: { label: string
   );
 }
 
+export const clientAreaContainerClass = 'mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 xl:px-10';
+
 export function PageShell({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
   return (
     <main className="min-h-screen bg-gradient-to-b from-orange-50 via-white to-white pt-24">
-      <section className="px-6 pb-12 pt-5 md:px-16 lg:px-28">
-        <div className="mx-auto max-w-6xl">
+      <section className="pb-12 pt-5">
+        <div className={clientAreaContainerClass}>
           <Breadcrumbs items={[{ label: 'Área do Cliente', href: '/area-do-cliente' }, { label: title }]} />
           <div className="overflow-hidden rounded-[2rem] border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-50 p-6 text-slate-900 shadow-xl shadow-orange-100/60 md:p-8">
-            <div className="max-w-4xl">
+            <div className="max-w-5xl">
               <span className="inline-flex rounded-full bg-orange-100 px-4 py-2 text-sm font-bold uppercase tracking-[0.2em] text-orange-700">
                 Central do Cliente SolarInvest
               </span>

--- a/src/components/cliente/ClientAreaLayout.tsx
+++ b/src/components/cliente/ClientAreaLayout.tsx
@@ -22,7 +22,7 @@ export function Breadcrumbs({ items, compact = false }: { items: { label: string
   );
 }
 
-export const clientAreaContainerClass = 'mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 xl:px-10';
+export const clientAreaContainerClass = 'mx-auto w-full max-w-[1320px] px-4 sm:px-6 lg:px-8';
 
 export function PageShell({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
   return (
@@ -30,15 +30,15 @@ export function PageShell({ title, description, children }: { title: string; des
       <section className="pb-12 pt-5">
         <div className={clientAreaContainerClass}>
           <Breadcrumbs items={[{ label: 'Área do Cliente', href: '/area-do-cliente' }, { label: title }]} />
-          <div className="overflow-hidden rounded-[2rem] border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-50 p-6 text-slate-900 shadow-xl shadow-orange-100/60 md:p-8">
-            <div className="max-w-5xl">
+          <div className="overflow-hidden rounded-3xl border border-orange-100 bg-gradient-to-br from-white via-orange-50 to-amber-50 p-6 text-slate-900 shadow-xl shadow-orange-100/60 md:p-8">
+            <div className="w-full">
               <span className="inline-flex rounded-full bg-orange-100 px-4 py-2 text-sm font-bold uppercase tracking-[0.2em] text-orange-700">
                 Central do Cliente SolarInvest
               </span>
               <h1 className="mt-4 text-4xl font-black tracking-tight text-slate-900 md:text-5xl">
                 {title}
               </h1>
-              <p className="mt-3 max-w-3xl text-lg leading-relaxed text-slate-700">
+              <p className="mt-3 max-w-[860px] text-lg leading-relaxed text-slate-700">
                 {description}
               </p>
             </div>


### PR DESCRIPTION
### Motivation
- Aumentar a largura útil das páginas da Área do Cliente em desktop para evitar conteúdo preso à esquerda e reduzir rolagem vertical mantendo legibilidade de textos longos.
- Aplicar o ajuste apenas às páginas da Área do Cliente, sem afetar o restante do site.

### Description
- Adiciona `clientAreaContainerClass = 'mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 xl:px-10'` em `src/components/cliente/ClientAreaLayout.tsx` e passa a usá-lo como wrapper nas páginas da Área do Cliente via `PageShell` e importação em `area-do-cliente/page.tsx`.
- Ajusta o header interno para usar `max-w-5xl` (antes `max-w-4xl`) e mantém textos longos com `max-w-3xl` para legibilidade dentro do novo container.
- Reestrutura `src/app/area-do-cliente/limpeza-modulos/page.tsx` para layout em grid com sidebar fixa (`lg:grid-cols-[minmax(0,1fr)_360px]`), torna o artigo `min-w-0` e converte blocos em grids responsivos para obter 2 colunas no desktop (cards informativos e `passo a passo`) e 1 coluna em mobile.
- Substitui paddings/containers locais (`px-6 md:px-16 lg:px-28` + various `max-w-*`) nas páginas da Área do Cliente por `clientAreaContainerClass` para centralizar e aumentar a largura útil sem mudanças globais no site.

### Testing
- Executado `npm run lint` com sucesso (sem warnings ou erros). 
- Executado `npm run build` com sucesso (compilou e gerou páginas estáticas). 
- Tentativa de teste visual com Playwright falhou na instalação (`npx playwright` retornou `403 Forbidden` pelo registry`), portanto screenshots/visual regression não foram gerados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32938687408331bfc79bdc65eaf61c)