### PR TITLE
Corrige manual operacional SDR: limpa header, remove badge, adiciona perguntas sobre UC/rateio/leasing e ajusta busca

### DIFF
--- a/src/components/SDRManualSearch.tsx
+++ b/src/components/SDRManualSearch.tsx
@@ -14,7 +14,7 @@ export function normalizeText(text: string) {
     .trim();
 }
 
-type SearchRecord = SDRManualItem & { category: string; haystack: string; normalizedQuestion: string; normalizedTags: string; normalizedAnswer: string };
+type SearchRecord = SDRManualItem & { category: string; haystack: string; normalizedQuestion: string; normalizedTags: string; normalizedShortAnswer: string; normalizedAnswer: string };
 
 const priorityLabel = { qualified: 'Lead qualificado', review: 'Analisar', disqualified: 'Não qualificado' } as const;
 const priorityClass = {
@@ -25,12 +25,20 @@ const priorityClass = {
 
 function scoreRecord(record: SearchRecord, query: string) {
   if (!query) return 0;
-  if (record.normalizedQuestion === query) return 500;
-  if (record.normalizedQuestion.includes(query)) return 400;
-  if (record.normalizedTags.includes(query)) return 300;
-  if (record.normalizedAnswer.includes(query)) return 200;
+  if (record.normalizedQuestion === query) return 1000;
+  if (record.normalizedQuestion.includes(query)) return 800;
+  if (record.normalizedTags.split(' ').includes(query) || record.normalizedTags.includes(query)) return 600;
+  if (record.normalizedShortAnswer.includes(query)) return 400;
+  if (record.normalizedAnswer.includes(query)) return 250;
+
   const terms = query.split(' ').filter(Boolean);
-  return terms.reduce((score, term) => score + (record.normalizedQuestion.includes(term) ? 40 : record.haystack.includes(term) ? 12 : 0), 0);
+  return terms.reduce((score, term) => {
+    if (record.normalizedQuestion.includes(term)) return score + 80;
+    if (record.normalizedTags.includes(term)) return score + 60;
+    if (record.normalizedShortAnswer.includes(term)) return score + 40;
+    if (record.normalizedAnswer.includes(term)) return score + 20;
+    return record.haystack.includes(term) ? score + 8 : score;
+  }, 0);
 }
 
 export default function SDRManualSearch() {
@@ -44,7 +52,8 @@ export default function SDRManualSearch() {
     const normalizedQuestion = normalizeText(item.question);
     const normalizedAnswer = normalizeText(item.answer);
     const normalizedTags = normalizeText(item.tags.join(' '));
-    return { ...item, category: category.category, normalizedQuestion, normalizedAnswer, normalizedTags, haystack: normalizeText(`${category.category} ${item.question} ${item.shortAnswer} ${item.answer} ${item.tags.join(' ')}`) };
+    const normalizedShortAnswer = normalizeText(item.shortAnswer);
+    return { ...item, category: category.category, normalizedQuestion, normalizedAnswer, normalizedTags, normalizedShortAnswer, haystack: normalizeText(`${category.category} ${item.question} ${item.shortAnswer} ${item.answer} ${item.tags.join(' ')}`) };
   })), []);
 
   const normalizedQuery = normalizeText(query);
@@ -79,23 +88,22 @@ export default function SDRManualSearch() {
     <main id="top" className="-mt-[72px] min-h-screen bg-slate-50 text-slate-900">
       <section className="bg-gradient-to-br from-slate-950 via-slate-900 to-orange-950 px-4 py-10 text-white md:px-8">
         <div className="mx-auto flex max-w-7xl flex-col gap-6 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-4"><Image src="/icon.png" width={72} height={72} alt="Logo SolarInvest" className="rounded-2xl bg-white/95 p-2" /><div><p className="text-sm font-bold uppercase tracking-[0.25em] text-orange-300">Base interna não listada</p><h1 className="mt-2 text-3xl font-black md:text-5xl">Manual Operacional SDR SolarInvest</h1><p className="mt-3 max-w-3xl text-slate-200">Atendimento inicial, qualificação de leads, perguntas frequentes e respostas padrão.</p></div></div>
-          <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm text-orange-50">Acesso por URL direta • noindex,nofollow • não exibido na navegação pública</div>
+          <div className="flex items-center gap-4"><Image src="/icon.png" width={72} height={72} alt="Logo SolarInvest" className="shrink-0 rounded-2xl bg-white/95 p-2" /><div><h1 className="text-3xl font-black md:text-5xl">Manual Operacional SDR SolarInvest</h1><p className="mt-3 max-w-3xl text-slate-200">Atendimento inicial, qualificação de leads, perguntas frequentes e respostas padrão.</p></div></div>
         </div>
       </section>
 
       <div className="sticky top-0 z-30 border-b border-orange-100 bg-white/95 px-4 py-4 shadow-sm backdrop-blur md:top-0 md:px-8">
-        <div className="mx-auto max-w-7xl"><label htmlFor="sdr-search" className="text-sm font-bold text-slate-700">Busca inteligente do manual</label><input id="sdr-search" value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Digite: entrada, falta energia, terreno, vender energia..." className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-5 py-4 text-base shadow-inner outline-none ring-orange-400 transition focus:ring-2" />
+        <div className="mx-auto max-w-7xl"><label htmlFor="sdr-search" className="text-sm font-bold text-slate-700">Busca inteligente do manual</label><input id="sdr-search" value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Digite: rateio, titularidade, UC, comprar sistema, buyout..." className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-5 py-4 text-base shadow-inner outline-none ring-orange-400 transition focus:ring-2" />
         {query ? <div className="mt-3 grid gap-2 md:grid-cols-2">{suggestions.length ? suggestions.map((item) => <button key={item.id} onClick={() => selectQuestion(item.id)} className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-left transition hover:border-orange-300 hover:bg-orange-50" aria-label={`Ir para ${item.question}`}><span className="block font-bold text-slate-900">{item.question}</span><span className="text-xs text-slate-500">{item.category}</span></button>) : <p className="rounded-xl bg-slate-100 px-4 py-3 text-sm text-slate-600">Nenhuma sugestão encontrada. Tente outra palavra-chave.</p>}</div> : null}</div>
       </div>
 
       <div className="mx-auto grid max-w-7xl gap-6 px-4 py-8 md:grid-cols-[280px_1fr] md:px-8">
         <aside className="space-y-4 md:sticky md:top-32 md:self-start"><div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200"><h2 className="font-black">Categorias</h2><div className="mt-3 flex gap-2 overflow-x-auto md:flex-col md:overflow-visible">{sdrManual.map((category) => <a key={category.category} href={`#cat-${normalizeText(category.category).replaceAll(' ', '-')}`} onClick={() => setActiveCategory(category.category)} className={`whitespace-nowrap rounded-full px-3 py-2 text-sm font-semibold transition md:whitespace-normal ${activeCategory === category.category ? 'bg-orange-500 text-white' : 'bg-slate-100 text-slate-700 hover:bg-orange-100'}`}>{category.category}</a>)}</div></div>
-        <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200"><h2 className="font-black">Checklist rápido do SDR</h2><ul className="mt-3 space-y-2 text-sm text-slate-700">{sdrChecklist.map((item) => <li key={item} className="flex gap-2"><span className="mt-1 h-3 w-3 rounded border border-orange-400" />{item}</li>)}</ul></div>
+        <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200"><h2 className="font-black">Checklist rápido do SDR</h2><ul className="mt-3 space-y-2 text-sm text-slate-700">{sdrChecklist.map((item) => <li key={item} className="flex gap-2"><span className="mt-1 h-3 w-3 rounded border border-orange-400" />{item}</li>)}</ul><div className="mt-4 rounded-2xl border border-orange-200 bg-orange-50 p-3 text-sm font-semibold leading-6 text-orange-950">Para Leasing Solar, a UC deve estar em nome do contratante. Caso exista rateio para outras unidades, as UCs envolvidas também devem estar regularizadas conforme as regras da distribuidora. Solicitações e alterações de rateio são responsabilidade do contratante, com possível auxílio da SolarInvest.</div></div>
         <div className="rounded-2xl bg-orange-50 p-4 shadow-sm ring-1 ring-orange-200"><h2 className="font-black text-orange-900">Critérios rápidos de qualificação</h2><ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-orange-950">{quickQualificationCriteria.map((item) => <li key={item}>{item}</li>)}</ul></div></aside>
 
         <section className="space-y-6"><div className="grid gap-3 md:grid-cols-3"><span className="rounded-2xl bg-emerald-100 px-4 py-3 text-center font-bold text-emerald-800">Lead qualificado</span><span className="rounded-2xl bg-amber-100 px-4 py-3 text-center font-bold text-amber-800">Analisar</span><span className="rounded-2xl bg-red-100 px-4 py-3 text-center font-bold text-red-800">Não qualificado</span></div>
-          {sdrManual.map((category) => <div key={category.category} id={`cat-${normalizeText(category.category).replaceAll(' ', '-')}`} className="scroll-mt-32"><div className="mb-3"><h2 className="text-2xl font-black text-slate-950">{category.category}</h2><p className="text-slate-600">{category.description}</p></div><div className="space-y-3">{category.items.map((item) => { const isOpen = openId === item.id; const isSelected = selectedId === item.id; return <article key={item.id} id={item.id} className={`scroll-mt-36 rounded-2xl bg-white shadow-sm ring-1 transition ${isSelected ? 'ring-4 ring-orange-300' : 'ring-slate-200'}`}><button onClick={() => { setOpenId(isOpen ? '' : item.id); setSelectedId(item.id); }} className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left" aria-expanded={isOpen} aria-controls={`${item.id}-panel`}><span><span className="block text-lg font-black text-slate-950">{item.question}</span><span className="mt-1 block text-sm text-slate-600">{item.shortAnswer}</span></span><span className="text-2xl text-orange-500">{isOpen ? '−' : '+'}</span></button>{isOpen ? <div id={`${item.id}-panel`} className="border-t border-slate-100 px-5 py-4"><div className="mb-3 flex flex-wrap gap-2"><span className={`rounded-full px-3 py-1 text-xs font-black ring-1 ${priorityClass[item.priority ?? 'review']}`}>{priorityLabel[item.priority ?? 'review']}</span>{item.tags.slice(0, 5).map((tag) => <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">{tag}</span>)}</div><p className="leading-8 text-slate-700">{item.answer}</p><button onClick={() => copyAnswer(item)} className="mt-4 rounded-full bg-slate-950 px-4 py-2 text-sm font-bold text-white transition hover:bg-orange-600" aria-label={`Copiar resposta de ${item.question}`}>{copiedId === item.id ? 'Resposta copiada' : 'Copiar resposta'}</button></div> : null}</article>; })}</div></div>)}
+          {sdrManual.map((category) => <div key={category.category} id={`cat-${normalizeText(category.category).replaceAll(' ', '-')}`} className="scroll-mt-32"><div className="mb-3"><h2 className="text-2xl font-black text-slate-950">{category.category}</h2><p className="text-slate-600">{category.description}</p></div><div className="space-y-3">{category.items.map((item) => { const isOpen = openId === item.id; const isSelected = selectedId === item.id; return <article key={item.id} id={item.id} className={`scroll-mt-36 rounded-2xl bg-white shadow-sm ring-1 transition ${isSelected ? 'ring-4 ring-orange-300' : 'ring-slate-200'}`}><button onClick={() => { setOpenId(isOpen ? '' : item.id); setSelectedId(item.id); setActiveCategory(category.category); }} className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left" aria-expanded={isOpen} aria-controls={`${item.id}-panel`}><span><span className="block text-lg font-black text-slate-950">{item.question}</span><span className="mt-1 block text-sm text-slate-600">{item.shortAnswer}</span></span><span className="text-2xl text-orange-500">{isOpen ? '−' : '+'}</span></button>{isOpen ? <div id={`${item.id}-panel`} className="border-t border-slate-100 px-5 py-4"><div className="mb-3 flex flex-wrap gap-2"><span className={`rounded-full px-3 py-1 text-xs font-black ring-1 ${priorityClass[item.priority ?? 'review']}`}>{priorityLabel[item.priority ?? 'review']}</span>{item.tags.slice(0, 5).map((tag) => <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">{tag}</span>)}</div><p className="leading-8 text-slate-700">{item.answer}</p><button onClick={() => copyAnswer(item)} className="mt-4 rounded-full bg-slate-950 px-4 py-2 text-sm font-bold text-white transition hover:bg-orange-600" aria-label={`Copiar resposta de ${item.question}`}>{copiedId === item.id ? 'Resposta copiada' : 'Copiar resposta'}</button></div> : null}</article>; })}</div></div>)}
         </section>
       </div>
       <a href="#top" className="fixed bottom-6 right-6 rounded-full bg-orange-500 px-4 py-3 font-bold text-white shadow-lg transition hover:bg-orange-600" aria-label="Voltar ao topo">Topo ↑</a>

--- a/src/content/sdrManual.ts
+++ b/src/content/sdrManual.ts
@@ -14,19 +14,24 @@ export type SDRManualCategory = {
 };
 
 export const sdrChecklist = [
-  'Nome do cliente',
+  'Nome completo do contratante',
+  'CPF/CNPJ do contratante',
   'Telefone',
   'Cidade/UF',
   'Tipo de imóvel',
-  'Valor médio da conta',
   'Distribuidora',
-  'Possui energia solar?',
-  'Imóvel próprio?',
-  'Conta no nome do cliente?',
-  'Interesse: leasing, venda, monitoramento, assistência ou dúvida',
+  'Valor médio da conta',
+  'Consumo médio, quando disponível',
+  'Número da Unidade Consumidora (UC)',
+  'A titularidade da UC está em nome do contratante?',
+  'Todas as UCs envolvidas no rateio estão em nome do contratante?',
+  'O imóvel é próprio?',
+  'Possui autorização do proprietário, se aplicável?',
+  'Possui energia solar instalada?',
+  'Interesse: Leasing, Venda, Monitoramento, Assistência ou Dúvida',
   'Conta de energia recebida?',
   'Lead qualificado?',
-  'Encaminhado para consultor?',
+  'Encaminhado ao consultor?',
 ];
 
 export const quickQualificationCriteria = [
@@ -41,7 +46,6 @@ export const quickQualificationCriteria = [
 export const sdrManual: SDRManualCategory[] = [
   { category: 'Visão geral da SolarInvest', description: 'Posicionamento, papel do SDR e limites comerciais.', items: [
     { id: 'o-que-e-a-solarinvest', question: 'O que é a SolarInvest?', shortAnswer: 'Empresa especializada em energia solar, com foco em Leasing Solar e soluções fotovoltaicas.', answer: 'A SolarInvest é uma empresa especializada em soluções de energia solar. Nosso principal modelo de negócio é o Leasing Solar, no qual a própria SolarInvest realiza o investimento no sistema fotovoltaico e o cliente passa a pagar uma mensalidade normalmente inferior ao que pagava anteriormente pela energia elétrica. Também atuamos com venda de sistemas fotovoltaicos, monitoramento, assistência técnica, ampliação e adequação de usinas já existentes.', tags: ['solarinvest', 'empresa', 'leasing solar', 'energia solar'], priority: 'qualified' },
-    { id: 'o-sdr-vende', question: 'O SDR vende?', shortAnswer: 'Não. O SDR qualifica, coleta informações e encaminha leads com potencial ao consultor.', answer: 'Não. O papel do SDR é fazer o primeiro atendimento, entender a necessidade do cliente, identificar se o lead possui perfil compatível, coletar as informações básicas, solicitar a conta de energia e encaminhar o atendimento para um consultor quando houver potencial real. O SDR não deve prometer aprovação, valores finais, prazos definitivos ou condições comerciais sem validação do consultor.', tags: ['sdr', 'venda', 'consultor', 'atendimento', 'promessa'], priority: 'review' },
   ]},
   { category: 'Leasing Solar', description: 'Conceitos, propriedade, manutenção e regras gerais do leasing.', items: [
     { id: 'o-que-e-leasing-solar', question: 'O que é Leasing Solar?', shortAnswer: 'A SolarInvest investe no sistema e o cliente paga uma mensalidade pelo uso da usina.', answer: 'No Leasing Solar, a SolarInvest realiza o investimento necessário para aquisição e instalação do sistema fotovoltaico. O cliente não precisa comprar os equipamentos e passa a utilizar a energia gerada pela usina mediante pagamento de uma mensalidade prevista em contrato. Durante a vigência contratual, a SolarInvest permanece responsável pela operação, monitoramento e manutenção previstos no contrato. Ao término do prazo contratual, a propriedade do sistema pode ser transferida ao cliente conforme as condições contratuais.', tags: ['leasing', 'aluguel solar', 'sem entrada', 'mensalidade', 'sistema solar'], priority: 'qualified' },
@@ -74,6 +78,13 @@ export const sdrManual: SDRManualCategory[] = [
   ]},
   { category: 'Conta de energia e distribuidora', description: 'Faturas, créditos e responsabilidades da distribuidora.', items: [
     { id: 'cliente-recebe-conta-distribuidora', question: 'O cliente continuará recebendo conta da distribuidora?', shortAnswer: 'Sim, poderá receber cobranças de disponibilidade, iluminação, tributos e consumo não compensado.', answer: 'Sim. Mesmo com energia solar, o cliente pode continuar recebendo faturas da distribuidora com cobranças como custo de disponibilidade, iluminação pública, tributos, encargos e eventual consumo não compensado, conforme o caso.', tags: ['conta', 'distribuidora', 'fatura', 'custo de disponibilidade'], priority: 'review' },
+    { id: 'titularidade-uc-contratante', question: 'A titularidade da UC precisa estar no nome do contratante?', shortAnswer: 'Sim. Para Leasing Solar, a Unidade Consumidora deve estar em nome do contratante.', answer: 'Sim. Para contratação do Leasing Solar, a titularidade da Unidade Consumidora (UC) deve estar em nome do contratante. Caso a conta de energia esteja em nome de outra pessoa física ou jurídica, a regularização da titularidade deverá ser realizada antes da formalização do contrato ou conforme orientação específica da SolarInvest. Essa verificação deve fazer parte do checklist obrigatório do SDR.', tags: ['titularidade', 'UC', 'unidade consumidora', 'contratante', 'conta de energia', 'leasing', 'checklist'], priority: 'qualified' },
+    { id: 'todas-ucs-nome-contratante', question: 'Todas as Unidades Consumidoras precisam estar no nome do contratante?', shortAnswer: 'Sim. As UCs utilizadas no contrato e no rateio devem estar em nome do contratante.', answer: 'Sim. Para utilização de créditos, rateio ou compensação vinculada ao contrato, as Unidades Consumidoras devem estar em nome do contratante ou atender às regras legais e regulatórias aplicáveis da distribuidora. Em regra, a SolarInvest deve orientar o cliente de que todas as UCs envolvidas precisam estar regularizadas em nome do contratante para evitar atrasos, recusas ou problemas de compensação.', tags: ['UC', 'unidades consumidoras', 'titularidade', 'rateio', 'créditos', 'compensação', 'contratante', 'distribuidora'], priority: 'qualified' },
+    { id: 'responsavel-alterar-rateio-creditos', question: 'Quem é responsável por solicitar ou alterar o rateio dos créditos?', shortAnswer: 'O contratante é responsável pelas solicitações e alterações de rateio.', answer: 'A solicitação de inclusão, exclusão ou alteração de rateio de créditos junto à distribuidora é de responsabilidade do contratante. A SolarInvest pode auxiliar com orientações, documentos e acompanhamento quando possível, mas não deve prometer controle sobre o prazo, aceitação ou processamento da solicitação pela distribuidora.', tags: ['rateio', 'alteração de rateio', 'créditos', 'compensação', 'distribuidora', 'contratante', 'responsabilidade'], priority: 'review' },
+    { id: 'garantia-compensacao-apos-rateio', question: 'A SolarInvest garante a compensação dos créditos após alteração de rateio?', shortAnswer: 'Não. A compensação depende do processamento da distribuidora.', answer: 'Não. A compensação dos créditos depende exclusivamente do processamento realizado pela distribuidora de energia. Alterações de rateio podem gerar atrasos na compensação e a SolarInvest não consegue garantir datas, valores ou ciclos exatos de compensação. O SDR deve explicar que a SolarInvest pode auxiliar o cliente, mas não controla os prazos internos da distribuidora.', tags: ['rateio', 'compensação', 'créditos', 'distribuidora', 'atraso', 'fatura', 'SolarInvest'], priority: 'review' },
+    { id: 'alteracoes-rateio-atrasam-compensacao', question: 'Alterações no rateio podem atrasar a compensação dos créditos?', shortAnswer: 'Sim. Alterações de rateio tendem a gerar atraso temporário na compensação.', answer: 'Sim. Solicitações ou alterações de rateio podem gerar atraso temporário na compensação dos créditos de energia, pois dependem da análise e processamento da distribuidora. A SolarInvest não pode garantir que os créditos sejam compensados no mesmo ciclo de faturamento em que o cliente solicitou a alteração.', tags: ['rateio', 'atraso', 'compensação', 'créditos', 'distribuidora', 'ciclo de faturamento'], priority: 'review' },
+    { id: 'cliente-pode-comprar-sistema-leasing', question: 'O cliente pode comprar o sistema depois de aderir ao Leasing Solar?', shortAnswer: 'Sim. O contrato pode prever aquisição antecipada conforme regras comerciais vigentes.', answer: 'Sim. O cliente pode solicitar a compra antecipada do sistema após aderir ao Leasing Solar, conforme as condições previstas no contrato e na política comercial vigente da SolarInvest. O valor de aquisição pode variar de acordo com o momento da solicitação, prazo já cumprido, saldo contratual, regras de buyout e condições específicas da proposta. O SDR não deve informar valor de compra por conta própria; deve encaminhar a solicitação ao consultor.', tags: ['comprar sistema', 'compra antecipada', 'leasing', 'buyout', 'aquisição', 'valor residual', 'contrato', 'comprar depois'], priority: 'review' },
+    { id: 'quando-comprar-sistema-leasing', question: 'Quando o cliente pode comprar o sistema no Leasing Solar?', shortAnswer: 'A compra antecipada depende das condições previstas no contrato.', answer: 'A possibilidade de compra antecipada depende das condições previstas no contrato de Leasing Solar e da política comercial vigente. O SDR deve informar que existe essa possibilidade, mas que a simulação de valor e o momento aplicável precisam ser confirmados por um consultor ou pela equipe responsável.', tags: ['comprar', 'leasing', 'compra antecipada', 'contrato', 'buyout', 'consultor', 'aquisição antecipada'], priority: 'review' },
     { id: 'solarinvest-controla-creditos', question: 'A SolarInvest controla a compensação de créditos?', shortAnswer: 'Não. Compensação, rateio e processamento na fatura são feitos pela distribuidora.', answer: 'Não. A compensação de energia, o rateio de créditos e o processamento na fatura são realizados pela distribuidora, conforme regras regulatórias. A SolarInvest pode acompanhar e orientar, mas não controla os prazos e critérios internos da distribuidora.', tags: ['créditos', 'creditos', 'compensação', 'rateio', 'distribuidora'], priority: 'review' },
   ]},
   { category: 'Monitoramento, Wi-Fi e manutenção', description: 'Conectividade, monitoramento remoto e impacto operacional.', items: [


### PR DESCRIPTION
### Motivation
- Remover avisos administrativos no topo do manual SDR sem alterar a configuração técnica de indexação (`noindex,nofollow`) ou o acesso por URL direta.
- Eliminar a pergunta irrelevante "O SDR vende?" da base e da busca para evitar confusão operacional.
- Incluir perguntas obrigatórias sobre titularidade da UC, rateio de créditos e compra antecipada em Leasing para orientar o checklist do SDR.
- Melhorar a relevância da busca e o comportamento de seleção para que termos como `rateio`, `titularidade`, `UC` e `comprar sistema` retornem resultados prioritários.

### Description
- Atualiza `src/components/SDRManualSearch.tsx` para limpar o header visual (remove badges/textos "Base interna não listada" e "Acesso por URL direta • noindex,nofollow • não exibido na navegação pública"), ajustar o `placeholder` da busca, inserir o alerta visual no checklist e expandir o comportamento de seleção para atualizar a categoria ativa quando um card é aberto.
- Altera a lógica de pontuação da busca em `src/components/SDRManualSearch.tsx` para priorizar `normalizedQuestion` > `normalizedTags` > `normalizedShortAnswer` > `normalizedAnswer` e adiciona `normalizedShortAnswer` ao índice para melhorar ranking conforme a ordem recomendada.
- Atualiza `src/content/sdrManual.ts` para expandir o `sdrChecklist` com os campos solicitados e adicionar as novas perguntas na categoria `Conta de energia e distribuidora` com os IDs `titularidade-uc-contratante`, `todas-ucs-nome-contratante`, `responsavel-alterar-rateio-creditos`, `garantia-compensacao-apos-rateio`, `alteracoes-rateio-atrasam-compensacao`, `cliente-pode-comprar-sistema-leasing`, `quando-comprar-sistema-leasing` e mantém a pergunta sobre controle de créditos existente.
- Mantém a rota e metadados de página em `src/app/sdr/manual-operacional/page.tsx` com `robots: { index: false, follow: false }` para preservar `noindex,nofollow` tecnicamente.
- Preserva o botão `Copiar resposta` que grava a `answer` completa no clipboard sem tags ou formatação adicional.

### Testing
- Executed `npm run lint` with no ESLint warnings or errors (passed).
- Executed `npm run build` and the Next.js production build completed successfully (passed).
- Ran project-wide searches/validations (ripgrep and small Python checks) that confirm the removed UI phrases are no longer present in the component view and that the new questions exist in `src/content/sdrManual.ts` (passed).
- Attempted an automated browser screenshot to visually verify layout, but Playwright was not available in the environment so the screenshot step could not run (skipped due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4d37328bbc83318615e65b08a04de4)