### PR TITLE
Proxy /fatura/:token to app.solarinvest.info and exempt it from site CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ module.exports = {
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: '/:path((?!fatura(?:/|$)).*)',
         headers: [
           {
             key: 'Content-Security-Policy',
@@ -70,6 +70,10 @@ module.exports = {
 
   async rewrites() {
     return [
+      {
+        source: '/fatura/:token',
+        destination: 'https://app.solarinvest.info/fatura/:token',
+      },
       {
         source: '/sitemap.xml',
         destination: '/sitemap',


### PR DESCRIPTION
### Motivation

- Allow public invoice pages to be opened at `solarinvest.info/fatura/<token>` while keeping the apex URL in the browser by proxying the path to the app at `https://app.solarinvest.info/fatura/:token` (no redirect). 
- Ensure the proxied invoice response is not blocked by the site's global `Content-Security-Policy` because the invoice page relies on an inline `<script>` (copy Pix button). 
- Keep signing/validation secret only in the app project and avoid introducing any `BILLING_INVOICE_LINK_SECRET` or token validation logic in this repository.

### Description

- Updated `next.config.js` to add a rewrite entry: `source: '/fatura/:token'` → `destination: 'https://app.solarinvest.info/fatura/:token'`, inserted before existing rewrites. 
- Adjusted the global headers rule to exclude `/fatura` paths by changing the header `source` to `/:path((?!fatura(?:/|$)).*)`, so the CSP and other headers are not applied to the proxied invoice responses. 
- Did not add or modify any environment secrets in this repo and committed the change with message `Add invoice rewrite for app fatura links` on branch `work`.

### Testing

- Ran `npm test` which printed "No tests specified" and completed successfully. 
- Ran `npm run lint` (`next lint`) and confirmed `✔ No ESLint warnings or errors`. 
- Ran `npm run build` (`next build`) and confirmed a successful production build and page generation with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a734b3fd2448331b31a10646ea070de)